### PR TITLE
Adds trapezoid shape to 3D printed shim

### DIFF
--- a/shim/shim.scad
+++ b/shim/shim.scad
@@ -19,8 +19,17 @@ module pegs() {
 }
 
 module outer() {
-	translate([-10, -4, 0.01])
-		cube([20, 4, total_height]);
+    port_height = total_height;
+    port_width_small = 20;
+    port_width_big = 21;
+    port_thickness = 4;
+	
+    translate([0, 0, 0.01])
+        difference(){
+            linear_extrude(height = port_height, scale = port_width_big/port_width_small) square(port_width_small, center = true);
+            translate([-25/2,-20-port_thickness,-1])cube([25, 20, port_height+2]);
+            translate([-25/2,3,-1])cube([25, 20, port_height+2]);
+        }
 }
 
 module inner() {

--- a/shim/shim.stl
+++ b/shim/shim.stl
@@ -1100,181 +1100,6 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 6.25 -4 0.00999928
-      vertex 10 0 0.00999928
-      vertex 10 -4 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 8 3 0.00999928
-      vertex 10 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8 6 0.00999928
-      vertex 10 6 0.00999928
-      vertex 8 3 0.00999928
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 8.00482 6.19627 0.00999928
-      vertex 10 6 0.00999928
-      vertex 8 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.77772 9.32588 0.00999928
-      vertex 9.94359 9.43091 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.6172 9.21283 0.00999928
-      vertex 9.77772 9.32588 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.46243 9.09204 0.00999928
-      vertex 9.6172 9.21283 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.31376 8.9638 0.00999928
-      vertex 9.46243 9.09204 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.17157 8.82843 0.00999928
-      vertex 9.31376 8.9638 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 9.03619 8.68624 0.00999928
-      vertex 9.17157 8.82843 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.90796 8.53757 0.00999928
-      vertex 9.03619 8.68624 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.78717 8.3828 0.00999928
-      vertex 8.90796 8.53757 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.67412 8.22228 0.00999928
-      vertex 8.78717 8.3828 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.56909 8.05641 0.00999928
-      vertex 8.67412 8.22228 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.47231 7.88559 0.00999928
-      vertex 8.56909 8.05641 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.38404 7.71022 0.00999928
-      vertex 8.47231 7.88559 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.30448 7.53073 0.00999928
-      vertex 8.38404 7.71022 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.23382 7.34756 0.00999928
-      vertex 8.30448 7.53073 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.17224 7.16114 0.00999928
-      vertex 8.23382 7.34756 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.07686 6.78036 0.00999928
-      vertex 8.11987 6.97192 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.04329 6.58692 0.00999928
-      vertex 8.07686 6.78036 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.01926 6.39207 0.00999928
-      vertex 8.04329 6.58692 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 6 0.00999928
-      vertex 8.11987 6.97192 0.00999928
-      vertex 8.17224 7.16114 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.25 3 0.00999928
-      vertex 10 0 0.00999928
-      vertex 6.25 -4 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 6.25 3 0.00999928
-      vertex 8 3 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex 13.6064 4.8086 0.00999928
       vertex 16 6 0.00999928
       vertex 16 0 0.00999928
@@ -1625,261 +1450,422 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 10 0 0.00999928
+      vertex 16 0 0.00999928
+      vertex 12.2935 4.02165 0.00999928
       vertex 12.3902 4.03843 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 12.196 4.00963 0.00999928
+      vertex 12.2935 4.02165 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 12.0981 4.00241 0.00999928
+      vertex 12.196 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 12 4 0.00999928
+      vertex 12.0981 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 11.9019 4.00241 0.00999928
+      vertex 12 4 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 11.804 4.00963 0.00999928
+      vertex 11.9019 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 11.7065 4.02165 0.00999928
+      vertex 11.804 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.25 0 0.00999928
+      vertex 11.7065 4.02165 0.00999928
       vertex 16 0 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 -0 -1
     outer loop
-      vertex 12.3902 4.03843 0.00999928
-      vertex 10 0 0.00999928
-      vertex 12.2935 4.02165 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.2935 4.02165 0.00999928
-      vertex 10 0 0.00999928
-      vertex 12.196 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.196 4.00963 0.00999928
-      vertex 10 0 0.00999928
-      vertex 12.0981 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.0981 4.00241 0.00999928
-      vertex 10 0 0.00999928
-      vertex 12 4 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12 4 0.00999928
-      vertex 10 0 0.00999928
-      vertex 11.9019 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.9019 4.00241 0.00999928
-      vertex 10 0 0.00999928
-      vertex 11.804 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.804 4.00963 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.7065 4.02165 0.00999928
+      vertex 6.25 0 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.7065 4.02165 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.6098 4.03843 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 11.6098 4.03843 0.00999928
-      vertex 10 0 0.00999928
       vertex 11.514 4.05994 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.514 4.05994 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.4194 4.08612 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.4194 4.08612 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.3262 4.11691 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.3262 4.11691 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.2346 4.15224 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.2346 4.15224 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.1449 4.19202 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.1449 4.19202 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 11.0572 4.23616 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 11.0572 4.23616 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 10.9718 4.28454 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 10.9718 4.28454 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 10.8889 4.33706 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
       vertex 10.8889 4.33706 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 3 0.00999928
       vertex 10.8086 4.39358 0.00999928
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex 10.8086 4.39358 0.00999928
-      vertex 10 0 0.00999928
-      vertex 10.7312 4.45398 0.00999928
+      vertex 10.8889 7.66294 0.00999928
+      vertex 9.77772 9.32588 0.00999928
+      vertex 9.94359 9.43091 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 10 0 0.00999928
-      vertex 10.6569 4.5181 0.00999928
-      vertex 10.7312 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.5858 4.58579 0.00999928
-      vertex 10.6569 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.5181 4.65688 0.00999928
-      vertex 10.5858 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.454 4.73121 0.00999928
-      vertex 10.5181 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.3936 4.8086 0.00999928
-      vertex 10.454 4.73121 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.3371 4.88886 0.00999928
-      vertex 10.3936 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.2845 4.97179 0.00999928
-      vertex 10.3371 4.88886 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.2362 5.05721 0.00999928
-      vertex 10.2845 4.97179 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.192 5.14489 0.00999928
-      vertex 10.2362 5.05721 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.1522 5.23463 0.00999928
-      vertex 10.192 5.14489 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.1169 5.32622 0.00999928
-      vertex 10.1522 5.23463 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0861 5.41943 0.00999928
-      vertex 10.1169 5.32622 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0599 5.51404 0.00999928
-      vertex 10.0861 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0384 5.60982 0.00999928
-      vertex 10.0599 5.51404 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0216 5.70654 0.00999928
-      vertex 10.0384 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0096 5.80397 0.00999928
-      vertex 10.0216 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 0 0.00999928
-      vertex 10.0024 5.90186 0.00999928
-      vertex 10.0096 5.80397 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 10.0024 5.90186 0.00999928
-      vertex 10 0 0.00999928
+      vertex 8 6 0.00999928
       vertex 10 6 0.00999928
+      vertex 10.0024 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 9.6172 9.21283 0.00999928
+      vertex 9.77772 9.32588 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0024 5.90186 0.00999928
+      vertex 10.0096 5.80397 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 9.46243 9.09204 0.00999928
+      vertex 9.6172 9.21283 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0096 5.80397 0.00999928
+      vertex 10.0216 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 9.31376 8.9638 0.00999928
+      vertex 9.46243 9.09204 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0216 5.70654 0.00999928
+      vertex 10.0384 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 9.17157 8.82843 0.00999928
+      vertex 9.31376 8.9638 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0384 5.60982 0.00999928
+      vertex 10.0599 5.51404 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 9.03619 8.68624 0.00999928
+      vertex 9.17157 8.82843 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0599 5.51404 0.00999928
+      vertex 10.0861 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.90796 8.53757 0.00999928
+      vertex 9.03619 8.68624 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.0861 5.41943 0.00999928
+      vertex 10.1169 5.32622 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.78717 8.3828 0.00999928
+      vertex 8.90796 8.53757 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.1169 5.32622 0.00999928
+      vertex 10.1522 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.67412 8.22228 0.00999928
+      vertex 8.78717 8.3828 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 6 0.00999928
+      vertex 10.1522 5.23463 0.00999928
+      vertex 10.192 5.14489 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.56909 8.05641 0.00999928
+      vertex 8.67412 8.22228 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.192 5.14489 0.00999928
+      vertex 10.2362 5.05721 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.47231 7.88559 0.00999928
+      vertex 8.56909 8.05641 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.2362 5.05721 0.00999928
+      vertex 10.2845 4.97179 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.38404 7.71022 0.00999928
+      vertex 8.47231 7.88559 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.2845 4.97179 0.00999928
+      vertex 10.3371 4.88886 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.30448 7.53073 0.00999928
+      vertex 8.38404 7.71022 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.3371 4.88886 0.00999928
+      vertex 10.3936 4.8086 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.23382 7.34756 0.00999928
+      vertex 8.30448 7.53073 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.3936 4.8086 0.00999928
+      vertex 10.454 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.17224 7.16114 0.00999928
+      vertex 8.23382 7.34756 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.454 4.73121 0.00999928
+      vertex 10.5181 4.65688 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.11987 6.97192 0.00999928
+      vertex 8.17224 7.16114 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.5181 4.65688 0.00999928
+      vertex 10.5858 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.07686 6.78036 0.00999928
+      vertex 8.11987 6.97192 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.5858 4.58579 0.00999928
+      vertex 10.6569 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.04329 6.58692 0.00999928
+      vertex 8.07686 6.78036 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 10.6569 4.5181 0.00999928
+      vertex 10.7312 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.8086 4.39358 0.00999928
+      vertex 8 3 0.00999928
+      vertex 10.7312 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 6 0.00999928
+      vertex 8 6 0.00999928
+      vertex 8.00482 6.19627 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 8.01926 6.39207 0.00999928
+      vertex 8.04329 6.58692 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.192 5.14489 0.00999928
+      vertex 8 3 0.00999928
+      vertex 8 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.6098 4.03843 0.00999928
+      vertex 8 3 0.00999928
+      vertex 11.514 4.05994 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8 3 0.00999928
+      vertex 6.25 0 0.00999928
+      vertex 6.25 3 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
@@ -2311,21 +2297,21 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.8889 7.66294 0.00999928
       vertex 10.8086 7.60641 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.8086 7.60641 0.00999928
       vertex 10.7312 7.54602 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.7312 7.54602 0.00999928
       vertex 10.6569 7.4819 0.00999928
     endloop
@@ -2339,14 +2325,14 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.6569 7.4819 0.00999928
       vertex 10.5858 7.41421 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.5858 7.41421 0.00999928
       vertex 10.5181 7.34312 0.00999928
     endloop
@@ -2360,21 +2346,21 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.5181 7.34312 0.00999928
       vertex 10.454 7.26879 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.454 7.26879 0.00999928
       vertex 10.3936 7.1914 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.3936 7.1914 0.00999928
       vertex 10.3371 7.11114 0.00999928
     endloop
@@ -2388,35 +2374,35 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.3371 7.11114 0.00999928
       vertex 10.2845 7.0282 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.2845 7.0282 0.00999928
       vertex 10.2362 6.94279 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.2362 6.94279 0.00999928
       vertex 10.192 6.85511 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.192 6.85511 0.00999928
       vertex 10.1522 6.76537 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.1522 6.76537 0.00999928
       vertex 10.1169 6.67378 0.00999928
     endloop
@@ -2430,42 +2416,42 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.1169 6.67378 0.00999928
       vertex 10.0861 6.58057 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.0861 6.58057 0.00999928
       vertex 10.0599 6.48596 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.0599 6.48596 0.00999928
       vertex 10.0384 6.39018 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.0384 6.39018 0.00999928
       vertex 10.0216 6.29346 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.0216 6.29346 0.00999928
       vertex 10.0096 6.19603 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 9.77772 9.32588 0.00999928
       vertex 10.0096 6.19603 0.00999928
       vertex 10.0024 6.09813 0.00999928
     endloop
@@ -2479,77 +2465,245 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 9.94359 9.43091 0.00999928
+      vertex 8.00482 6.19627 0.00999928
       vertex 10.0024 6.09813 0.00999928
       vertex 10 6 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 10 6 0.00999928
+      vertex 10.0024 6.09813 0.00999928
       vertex 8.00482 6.19627 0.00999928
       vertex 8.01926 6.39207 0.00999928
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
+      vertex -6.25 0 0.00999928
+      vertex -8 3 0.00999928
+      vertex -6.25 3 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.192 5.14489 0.00999928
+      vertex -8 6 0.00999928
+      vertex -8 3 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10.1169 5.32622 0.00999928
+      vertex -8 6 0.00999928
+      vertex -10.1522 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10.0599 5.51404 0.00999928
+      vertex -8 6 0.00999928
+      vertex -10.0861 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10.0216 5.70654 0.00999928
+      vertex -8 6 0.00999928
+      vertex -10.0384 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10.0096 5.80397 0.00999928
+      vertex -8 6 0.00999928
+      vertex -10.0216 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -10 6 0.00999928
       vertex -8 6 0.00999928
       vertex -10.0024 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8 6 0.00999928
+      vertex -10 6 0.00999928
+      vertex -8.00482 6.19627 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.00482 6.19627 0.00999928
+      vertex -10.0024 6.09813 0.00999928
+      vertex -8.01926 6.39207 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.01926 6.39207 0.00999928
+      vertex -10.0096 6.19603 0.00999928
+      vertex -8.04329 6.58692 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0216 6.29346 0.00999928
+      vertex -8.04329 6.58692 0.00999928
+      vertex -10.0096 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0384 6.39018 0.00999928
+      vertex -8.07686 6.78036 0.00999928
+      vertex -10.0216 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0599 6.48596 0.00999928
+      vertex -8.11987 6.97192 0.00999928
+      vertex -10.0384 6.39018 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.11987 6.97192 0.00999928
+      vertex -10.0599 6.48596 0.00999928
+      vertex -8.17224 7.16114 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.17224 7.16114 0.00999928
+      vertex -10.0861 6.58057 0.00999928
+      vertex -8.23382 7.34756 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1169 6.67378 0.00999928
+      vertex -8.23382 7.34756 0.00999928
+      vertex -10.0861 6.58057 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1522 6.76537 0.00999928
+      vertex -8.30448 7.53073 0.00999928
+      vertex -10.1169 6.67378 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.192 6.85511 0.00999928
+      vertex -8.38404 7.71022 0.00999928
+      vertex -10.1522 6.76537 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.38404 7.71022 0.00999928
+      vertex -10.192 6.85511 0.00999928
+      vertex -8.47231 7.88559 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.47231 7.88559 0.00999928
+      vertex -10.2362 6.94279 0.00999928
+      vertex -8.56909 8.05641 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.2845 7.0282 0.00999928
+      vertex -8.56909 8.05641 0.00999928
+      vertex -10.2362 6.94279 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3371 7.11114 0.00999928
+      vertex -8.67412 8.22228 0.00999928
+      vertex -10.2845 7.0282 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.23382 7.34756 0.00999928
+      vertex -10.1169 6.67378 0.00999928
+      vertex -8.30448 7.53073 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7065 4.02165 0.00999928
+      vertex -8 3 0.00999928
+      vertex -6.25 0 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0861 6.58057 0.00999928
+      vertex -8.17224 7.16114 0.00999928
+      vertex -10.0599 6.48596 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.07686 6.78036 0.00999928
+      vertex -10.0384 6.39018 0.00999928
+      vertex -8.11987 6.97192 0.00999928
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.04329 6.58692 0.00999928
+      vertex -10.0216 6.29346 0.00999928
+      vertex -8.07686 6.78036 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0096 6.19603 0.00999928
+      vertex -8.01926 6.39207 0.00999928
+      vertex -10.0024 6.09813 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.0024 6.09813 0.00999928
+      vertex -8.00482 6.19627 0.00999928
       vertex -10 6 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 -0 -1
     outer loop
-      vertex -8 3 0.00999928
-      vertex -10.0096 5.80397 0.00999928
       vertex -10.0024 5.90186 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 3 0.00999928
-      vertex -10.0216 5.70654 0.00999928
+      vertex -8 6 0.00999928
       vertex -10.0096 5.80397 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 -0 -1
     outer loop
-      vertex -8 3 0.00999928
       vertex -10.0384 5.60982 0.00999928
-      vertex -10.0216 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 3 0.00999928
-      vertex -10.0599 5.51404 0.00999928
-      vertex -10.0384 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 3 0.00999928
-      vertex -10.0861 5.41943 0.00999928
+      vertex -8 6 0.00999928
       vertex -10.0599 5.51404 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 -0 -1
     outer loop
-      vertex -8 3 0.00999928
-      vertex -10.1169 5.32622 0.00999928
       vertex -10.0861 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 3 0.00999928
-      vertex -10.1522 5.23463 0.00999928
+      vertex -8 6 0.00999928
       vertex -10.1169 5.32622 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -8 3 0.00999928
+      vertex -8 6 0.00999928
       vertex -10.192 5.14489 0.00999928
       vertex -10.1522 5.23463 0.00999928
     endloop
@@ -2647,107 +2801,107 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.1449 4.19202 0.00999928
       vertex -11.0572 4.23616 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.2346 4.15224 0.00999928
       vertex -11.1449 4.19202 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.3262 4.11691 0.00999928
       vertex -11.2346 4.15224 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.4194 4.08612 0.00999928
       vertex -11.3262 4.11691 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.514 4.05994 0.00999928
       vertex -11.4194 4.08612 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.6098 4.03843 0.00999928
       vertex -11.514 4.05994 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -8 3 0.00999928
       vertex -11.7065 4.02165 0.00999928
       vertex -11.6098 4.03843 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
+      vertex -6.25 0 0.00999928
       vertex -11.804 4.00963 0.00999928
       vertex -11.7065 4.02165 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -11.9019 4.00241 0.00999928
+      vertex -16 0 0.00999928
       vertex -11.804 4.00963 0.00999928
+      vertex -6.25 0 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -12 4 0.00999928
+      vertex -11.804 4.00963 0.00999928
+      vertex -16 0 0.00999928
       vertex -11.9019 4.00241 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -12.0981 4.00241 0.00999928
+      vertex -11.9019 4.00241 0.00999928
+      vertex -16 0 0.00999928
       vertex -12 4 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -12.196 4.00963 0.00999928
+      vertex -12 4 0.00999928
+      vertex -16 0 0.00999928
       vertex -12.0981 4.00241 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -12.2935 4.02165 0.00999928
+      vertex -12.0981 4.00241 0.00999928
+      vertex -16 0 0.00999928
       vertex -12.196 4.00963 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -12.3902 4.03843 0.00999928
+      vertex -12.196 4.00963 0.00999928
+      vertex -16 0 0.00999928
       vertex -12.2935 4.02165 0.00999928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 -1
     outer loop
+      vertex -12.2935 4.02165 0.00999928
       vertex -16 0 0.00999928
       vertex -12.3902 4.03843 0.00999928
-      vertex -10 0 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
@@ -2790,62 +2944,6 @@ solid OpenSCAD_Model
       vertex -12.8551 4.19202 0.00999928
       vertex -16 0 0.00999928
       vertex -12.9428 4.23616 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -12.9428 4.23616 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.0282 4.28454 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.0282 4.28454 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.1111 4.33706 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.1111 4.33706 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.1914 4.39358 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.1914 4.39358 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.2688 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.2688 4.45398 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.3431 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.3431 4.5181 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.4142 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.4142 4.58579 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.4819 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.4819 4.65688 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.546 4.73121 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
@@ -3030,20 +3128,6 @@ solid OpenSCAD_Model
       vertex -13.6064 4.8086 0.00999928
     endloop
   endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.546 4.73121 0.00999928
-      vertex -16 0 0.00999928
-      vertex -13.6064 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14 6 0.00999928
-      vertex -16 6 0.00999928
-      vertex -15.9952 6.19627 0.00999928
-    endloop
-  endfacet
   facet normal 0 0 -1
     outer loop
       vertex -13.9976 6.09813 0.00999928
@@ -3053,6 +3137,13 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
+      vertex -16 0 0.00999928
+      vertex -13.6064 4.8086 0.00999928
+      vertex -13.546 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex -13.9976 6.09813 0.00999928
       vertex -15.8278 7.16114 0.00999928
       vertex -15.7662 7.34756 0.00999928
@@ -3060,6 +3151,13 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
+      vertex -16 0 0.00999928
+      vertex -13.546 4.73121 0.00999928
+      vertex -13.4819 4.65688 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex -13.9976 6.09813 0.00999928
       vertex -15.8801 6.97192 0.00999928
       vertex -15.8278 7.16114 0.00999928
@@ -3067,6 +3165,13 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
+      vertex -16 0 0.00999928
+      vertex -13.4819 4.65688 0.00999928
+      vertex -13.4142 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex -13.9976 6.09813 0.00999928
       vertex -15.9231 6.78036 0.00999928
       vertex -15.8801 6.97192 0.00999928
@@ -3074,9 +3179,23 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
+      vertex -16 0 0.00999928
+      vertex -13.4142 4.58579 0.00999928
+      vertex -13.3431 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex -13.9976 6.09813 0.00999928
       vertex -15.9567 6.58692 0.00999928
       vertex -15.9231 6.78036 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16 0 0.00999928
+      vertex -13.3431 4.5181 0.00999928
+      vertex -13.2688 4.45398 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
@@ -3086,11 +3205,11 @@ solid OpenSCAD_Model
       vertex -15.9567 6.58692 0.00999928
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
-      vertex -13.6064 4.8086 0.00999928
       vertex -16 0 0.00999928
-      vertex -16 6 0.00999928
+      vertex -13.2688 4.45398 0.00999928
+      vertex -13.1914 4.39358 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
@@ -3102,177 +3221,37 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10 0 0.00999928
-      vertex -6.25 3 0.00999928
-      vertex -6.25 -4 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.0024 5.90186 0.00999928
-      vertex -8 6 0.00999928
-      vertex -8 3 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 6 0.00999928
-      vertex -10 6 0.00999928
-      vertex -8.00482 6.19627 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.0024 6.09813 0.00999928
-      vertex -8.00482 6.19627 0.00999928
-      vertex -10 6 0.00999928
+      vertex -16 0 0.00999928
+      vertex -13.1914 4.39358 0.00999928
+      vertex -13.1111 4.33706 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -8.00482 6.19627 0.00999928
-      vertex -10.0024 6.09813 0.00999928
-      vertex -8.01926 6.39207 0.00999928
+      vertex -12.9428 4.23616 0.00999928
+      vertex -16 0 0.00999928
+      vertex -13.0282 4.28454 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.0096 6.19603 0.00999928
-      vertex -8.01926 6.39207 0.00999928
-      vertex -10.0024 6.09813 0.00999928
+      vertex -16 0 0.00999928
+      vertex -13.1111 4.33706 0.00999928
+      vertex -13.0282 4.28454 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -8.01926 6.39207 0.00999928
-      vertex -10.0096 6.19603 0.00999928
-      vertex -8.04329 6.58692 0.00999928
+      vertex -13.6064 4.8086 0.00999928
+      vertex -16 0 0.00999928
+      vertex -16 6 0.00999928
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.0216 6.29346 0.00999928
-      vertex -8.04329 6.58692 0.00999928
-      vertex -10.0096 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.04329 6.58692 0.00999928
-      vertex -10.0216 6.29346 0.00999928
-      vertex -8.07686 6.78036 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.0384 6.39018 0.00999928
-      vertex -8.07686 6.78036 0.00999928
-      vertex -10.0216 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.07686 6.78036 0.00999928
-      vertex -10.0384 6.39018 0.00999928
-      vertex -8.11987 6.97192 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.0599 6.48596 0.00999928
-      vertex -8.11987 6.97192 0.00999928
-      vertex -10.0384 6.39018 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.11987 6.97192 0.00999928
-      vertex -10.0599 6.48596 0.00999928
-      vertex -8.17224 7.16114 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.0861 6.58057 0.00999928
-      vertex -8.17224 7.16114 0.00999928
-      vertex -10.0599 6.48596 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.17224 7.16114 0.00999928
-      vertex -10.0861 6.58057 0.00999928
-      vertex -8.23382 7.34756 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.1169 6.67378 0.00999928
-      vertex -8.23382 7.34756 0.00999928
-      vertex -10.0861 6.58057 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.1522 6.76537 0.00999928
-      vertex -8.30448 7.53073 0.00999928
-      vertex -10.1169 6.67378 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.192 6.85511 0.00999928
-      vertex -8.38404 7.71022 0.00999928
-      vertex -10.1522 6.76537 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.38404 7.71022 0.00999928
-      vertex -10.192 6.85511 0.00999928
-      vertex -8.47231 7.88559 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.47231 7.88559 0.00999928
-      vertex -10.2362 6.94279 0.00999928
-      vertex -8.56909 8.05641 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -6.25 3 0.00999928
-      vertex -10 0 0.00999928
-      vertex -8 3 0.00999928
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -8.23382 7.34756 0.00999928
-      vertex -10.1169 6.67378 0.00999928
-      vertex -8.30448 7.53073 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.2362 6.94279 0.00999928
-      vertex -8.47231 7.88559 0.00999928
-      vertex -10.192 6.85511 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10 0 0.00999928
-      vertex -6.25 -4 0.00999928
-      vertex -10 -4 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.0572 4.23616 0.00999928
-      vertex -8 3 0.00999928
-      vertex -10 0 0.00999928
+      vertex -14 6 0.00999928
+      vertex -16 6 0.00999928
+      vertex -15.9952 6.19627 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
@@ -3284,9 +3263,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.2845 7.0282 0.00999928
-      vertex -8.56909 8.05641 0.00999928
       vertex -10.2362 6.94279 0.00999928
+      vertex -8.47231 7.88559 0.00999928
+      vertex -10.192 6.85511 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
@@ -3294,13 +3273,6 @@ solid OpenSCAD_Model
       vertex -8.56909 8.05641 0.00999928
       vertex -10.2845 7.0282 0.00999928
       vertex -8.67412 8.22228 0.00999928
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.3371 7.11114 0.00999928
-      vertex -8.67412 8.22228 0.00999928
-      vertex -10.2845 7.0282 0.00999928
     endloop
   endfacet
   facet normal -0 0 -1
@@ -4131,44 +4103,72 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 -1 0
     outer loop
+      vertex 6.25 0 0.01
+      vertex 6.25 0 0.00999928
+      vertex 10 0 0.01
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
       vertex -16 0 14.41
-      vertex -10 0 13.21
+      vertex -10.5 0 13.21
       vertex 16 0 14.41
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex -16 0 0.00999928
-      vertex -10 0 13.21
+      vertex -10.5 0 13.21
       vertex -16 0 14.41
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex -10 0 13.21
+      vertex -10.5 0 13.21
       vertex -16 0 0.00999928
-      vertex -10 0 0.00999928
+      vertex -10 0 0.01
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 10 0 13.21
+      vertex -6.25 0 0.00999928
+      vertex -10 0 0.01
+      vertex -16 0 0.00999928
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -10 0 0.01
+      vertex -6.25 0 0.00999928
+      vertex -6.25 0 0.01
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.5 0 13.21
       vertex 16 0 14.41
-      vertex -10 0 13.21
+      vertex -10.5 0 13.21
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex 16 0 0.00999928
-      vertex 10 0 13.21
-      vertex 10 0 0.00999928
+      vertex 10.5 0 13.21
+      vertex 10 0 0.01
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 10 0 13.21
+      vertex 10.5 0 13.21
       vertex 16 0 0.00999928
       vertex 16 0 14.41
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 16 0 0.00999928
+      vertex 10 0 0.01
+      vertex 6.25 0 0.00999928
     endloop
   endfacet
   facet normal 0.997289 0.0735886 0
@@ -4526,27 +4526,6 @@ solid OpenSCAD_Model
       vertex -12.7804 9.92314 3.01
       vertex -12.5869 9.95671 0.00999928
       vertex -12.7804 9.92314 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244476 0
-    outer loop
-      vertex -15.9952 6.19627 0.00999928
-      vertex -15.9964 6.1472 3.00361
-      vertex -15.9952 6.19627 3.00723
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244488 2.04175e-08
-    outer loop
-      vertex -16 6 0.00999928
-      vertex -15.9964 6.1472 3.00361
-      vertex -15.9952 6.19627 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244492 0
-    outer loop
-      vertex -15.9964 6.1472 3.00361
-      vertex -16 6 0.00999928
-      vertex -16 6 3
     endloop
   endfacet
   facet normal 0.36003 0.932941 -0
@@ -4955,6 +4934,27 @@ solid OpenSCAD_Model
       vertex -15.3259 8.22228 3.01
     endloop
   endfacet
+  facet normal -0.999701 0.0244476 0
+    outer loop
+      vertex -15.9952 6.19627 0.00999928
+      vertex -15.9964 6.1472 3.00361
+      vertex -15.9952 6.19627 3.00723
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244488 2.04175e-08
+    outer loop
+      vertex -16 6 0.00999928
+      vertex -15.9964 6.1472 3.00361
+      vertex -15.9952 6.19627 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244492 0
+    outer loop
+      vertex -15.9964 6.1472 3.00361
+      vertex -16 6 0.00999928
+      vertex -16 6 3
+    endloop
+  endfacet
   facet normal -0.219185 0.975683 0
     outer loop
       vertex -12.7804 9.92314 0.00999928
@@ -5011,20 +5011,6 @@ solid OpenSCAD_Model
       vertex -13.1611 9.82776 0.00999928
     endloop
   endfacet
-  facet normal -0.96386 0.266409 0
-    outer loop
-      vertex -15.8801 6.97192 0.00999928
-      vertex -15.8278 7.16114 3.01
-      vertex -15.8278 7.16114 0.00999928
-    endloop
-  endfacet
-  facet normal -0.96386 0.266409 0
-    outer loop
-      vertex -15.8278 7.16114 3.01
-      vertex -15.8801 6.97192 0.00999928
-      vertex -15.8801 6.97192 3.01
-    endloop
-  endfacet
   facet normal -0.844936 0.534867 0
     outer loop
       vertex -15.4309 8.05641 0.00999928
@@ -5065,6 +5051,20 @@ solid OpenSCAD_Model
       vertex -15.616 7.71022 3.01
       vertex -15.6955 7.53073 0.00999928
       vertex -15.6955 7.53073 3.01
+    endloop
+  endfacet
+  facet normal -0.96386 0.266409 0
+    outer loop
+      vertex -15.8801 6.97192 0.00999928
+      vertex -15.8278 7.16114 3.01
+      vertex -15.8278 7.16114 0.00999928
+    endloop
+  endfacet
+  facet normal -0.96386 0.266409 0
+    outer loop
+      vertex -15.8278 7.16114 3.01
+      vertex -15.8801 6.97192 0.00999928
+      vertex -15.8801 6.97192 3.01
     endloop
   endfacet
   facet normal -0.405212 0.914223 0
@@ -7335,6 +7335,34 @@ solid OpenSCAD_Model
       vertex -8 3 6
     endloop
   endfacet
+  facet normal 0 0.949529 0.31368
+    outer loop
+      vertex -8 3.17537 4.98933
+      vertex -16 3.12918 5.12915
+      vertex -8 3.12918 5.12915
+    endloop
+  endfacet
+  facet normal 0 0.949529 0.31368
+    outer loop
+      vertex -16 3.12918 5.12915
+      vertex -8 3.17537 4.98933
+      vertex -16 3.17537 4.98933
+    endloop
+  endfacet
+  facet normal 0 0.949529 0.31368
+    outer loop
+      vertex 16 3.17537 4.98933
+      vertex 8 3.12918 5.12915
+      vertex 16 3.12918 5.12915
+    endloop
+  endfacet
+  facet normal 0 0.949529 0.31368
+    outer loop
+      vertex 8 3.12918 5.12915
+      vertex 16 3.17537 4.98933
+      vertex 8 3.17537 4.98933
+    endloop
+  endfacet
   facet normal 0 -0.0245171 0.999699
     outer loop
       vertex -8.00361 6.1472 3.00361
@@ -7937,6 +7965,146 @@ solid OpenSCAD_Model
       vertex 13.534 4.71733 3.28803
     endloop
   endfacet
+  facet normal -0 0.615233 0.788346
+    outer loop
+      vertex -11.1034 4.2129 3.59038
+      vertex -8 4.09682 3.68097
+      vertex -8 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal -6.52341e-06 0.615124 0.78843
+    outer loop
+      vertex -11.1449 4.19202 3.60667
+      vertex -8 4.09682 3.68097
+      vertex -11.1034 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 1.80494e-06 0.615295 0.788297
+    outer loop
+      vertex -11.2346 4.15224 3.63772
+      vertex -8 4.09682 3.68097
+      vertex -11.1449 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal -6.14946e-07 0.615208 0.788365
+    outer loop
+      vertex -11.3262 4.11691 3.66529
+      vertex -8 4.09682 3.68097
+      vertex -11.2346 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0 0.615271 0.788316
+    outer loop
+      vertex -8 4.09682 3.68097
+      vertex -11.3262 4.11691 3.66529
+      vertex -11.387 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal 0 0.615233 0.788346
+    outer loop
+      vertex 8 4.09682 3.68097
+      vertex 11.1034 4.2129 3.59038
+      vertex 8 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 6.52341e-06 0.615124 0.78843
+    outer loop
+      vertex 11.1034 4.2129 3.59038
+      vertex 8 4.09682 3.68097
+      vertex 11.1449 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal -1.80494e-06 0.615295 0.788297
+    outer loop
+      vertex 11.1449 4.19202 3.60667
+      vertex 8 4.09682 3.68097
+      vertex 11.2346 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 6.14946e-07 0.615208 0.788365
+    outer loop
+      vertex 11.2346 4.15224 3.63772
+      vertex 8 4.09682 3.68097
+      vertex 11.3262 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal 0 0.615271 0.788316
+    outer loop
+      vertex 11.3262 4.11691 3.66529
+      vertex 8 4.09682 3.68097
+      vertex 11.387 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal 0 0.615233 0.788346
+    outer loop
+      vertex -16 4.09682 3.68097
+      vertex -12.8966 4.2129 3.59038
+      vertex -16 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 6.52341e-06 0.615124 0.78843
+    outer loop
+      vertex -12.8966 4.2129 3.59038
+      vertex -16 4.09682 3.68097
+      vertex -12.8551 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal -1.80494e-06 0.615295 0.788297
+    outer loop
+      vertex -12.8551 4.19202 3.60667
+      vertex -16 4.09682 3.68097
+      vertex -12.7654 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 6.14946e-07 0.615208 0.788365
+    outer loop
+      vertex -12.7654 4.15224 3.63772
+      vertex -16 4.09682 3.68097
+      vertex -12.6738 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal 0 0.615271 0.788316
+    outer loop
+      vertex -12.6738 4.11691 3.66529
+      vertex -16 4.09682 3.68097
+      vertex -12.613 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal -0 0.615233 0.788346
+    outer loop
+      vertex 12.8966 4.2129 3.59038
+      vertex 16 4.09682 3.68097
+      vertex 16 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal -6.52341e-06 0.615124 0.78843
+    outer loop
+      vertex 12.8551 4.19202 3.60667
+      vertex 16 4.09682 3.68097
+      vertex 12.8966 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 1.80494e-06 0.615295 0.788297
+    outer loop
+      vertex 12.7654 4.15224 3.63772
+      vertex 16 4.09682 3.68097
+      vertex 12.8551 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal -6.14946e-07 0.615208 0.788365
+    outer loop
+      vertex 12.6738 4.11691 3.66529
+      vertex 16 4.09682 3.68097
+      vertex 12.7654 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0 0.615271 0.788316
+    outer loop
+      vertex 16 4.09682 3.68097
+      vertex 12.6738 4.11691 3.66529
+      vertex 12.613 4.09682 3.68097
+    endloop
+  endfacet
   facet normal 0 0.933 0.359875
     outer loop
       vertex -8 3.22836 4.85195
@@ -8271,6 +8439,118 @@ solid OpenSCAD_Model
       vertex 8 3.01445 5.70595
       vertex 16 3.03247 5.55981
       vertex 8 3.03247 5.55981
+    endloop
+  endfacet
+  facet normal -0 0.170937 0.985282
+    outer loop
+      vertex -10.0497 5.55981 3.03247
+      vertex -8 5.41473 3.05764
+      vertex -8 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal -9.89476e-07 0.170923 0.985284
+    outer loop
+      vertex -10.0599 5.51404 3.04041
+      vertex -8 5.41473 3.05764
+      vertex -10.0497 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 2.69356e-06 0.170998 0.985271
+    outer loop
+      vertex -10.0861 5.41943 3.05683
+      vertex -8 5.41473 3.05764
+      vertex -10.0599 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal 0 0.169837 0.985472
+    outer loop
+      vertex -8 5.41473 3.05764
+      vertex -10.0861 5.41943 3.05683
+      vertex -10.0877 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal 0 0.170937 0.985282
+    outer loop
+      vertex 8 5.41473 3.05764
+      vertex 10.0497 5.55981 3.03247
+      vertex 8 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 9.89476e-07 0.170923 0.985284
+    outer loop
+      vertex 10.0497 5.55981 3.03247
+      vertex 8 5.41473 3.05764
+      vertex 10.0599 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal -2.69356e-06 0.170998 0.985271
+    outer loop
+      vertex 10.0599 5.51404 3.04041
+      vertex 8 5.41473 3.05764
+      vertex 10.0861 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0 0.169837 0.985472
+    outer loop
+      vertex 10.0861 5.41943 3.05683
+      vertex 8 5.41473 3.05764
+      vertex 10.0877 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal 0 0.170937 0.985282
+    outer loop
+      vertex -16 5.41473 3.05764
+      vertex -13.9503 5.55981 3.03247
+      vertex -16 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 9.89476e-07 0.170923 0.985284
+    outer loop
+      vertex -13.9503 5.55981 3.03247
+      vertex -16 5.41473 3.05764
+      vertex -13.9401 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal -2.69356e-06 0.170998 0.985271
+    outer loop
+      vertex -13.9401 5.51404 3.04041
+      vertex -16 5.41473 3.05764
+      vertex -13.9139 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0 0.169837 0.985472
+    outer loop
+      vertex -13.9139 5.41943 3.05683
+      vertex -16 5.41473 3.05764
+      vertex -13.9123 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal -0 0.170937 0.985282
+    outer loop
+      vertex 13.9503 5.55981 3.03247
+      vertex 16 5.41473 3.05764
+      vertex 16 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal -9.89476e-07 0.170923 0.985284
+    outer loop
+      vertex 13.9401 5.51404 3.04041
+      vertex 16 5.41473 3.05764
+      vertex 13.9503 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 2.69356e-06 0.170998 0.985271
+    outer loop
+      vertex 13.9139 5.41943 3.05683
+      vertex 16 5.41473 3.05764
+      vertex 13.9401 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal 0 0.169837 0.985472
+    outer loop
+      vertex 16 5.41473 3.05764
+      vertex 13.9139 5.41943 3.05683
+      vertex 13.9123 5.41473 3.05764
     endloop
   endfacet
   facet normal -0 0.12238 0.992483
@@ -8749,34 +9029,6 @@ solid OpenSCAD_Model
       vertex 8 3.05764 5.41473
     endloop
   endfacet
-  facet normal 0 0.949529 0.31368
-    outer loop
-      vertex -8 3.17537 4.98933
-      vertex -16 3.12918 5.12915
-      vertex -8 3.12918 5.12915
-    endloop
-  endfacet
-  facet normal 0 0.949529 0.31368
-    outer loop
-      vertex -16 3.12918 5.12915
-      vertex -8 3.17537 4.98933
-      vertex -16 3.17537 4.98933
-    endloop
-  endfacet
-  facet normal 0 0.949529 0.31368
-    outer loop
-      vertex 16 3.17537 4.98933
-      vertex 8 3.12918 5.12915
-      vertex 16 3.12918 5.12915
-    endloop
-  endfacet
-  facet normal 0 0.949529 0.31368
-    outer loop
-      vertex 8 3.12918 5.12915
-      vertex 16 3.17537 4.98933
-      vertex 8 3.17537 4.98933
-    endloop
-  endfacet
   facet normal -0 0.492851 0.870113
     outer loop
       vertex -10.5858 4.58581 3.35424
@@ -8973,146 +9225,6 @@ solid OpenSCAD_Model
       vertex 8 3.68097 4.09682
     endloop
   endfacet
-  facet normal -0 0.615233 0.788346
-    outer loop
-      vertex -11.1034 4.2129 3.59038
-      vertex -8 4.09682 3.68097
-      vertex -8 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal -6.52341e-06 0.615124 0.78843
-    outer loop
-      vertex -11.1449 4.19202 3.60667
-      vertex -8 4.09682 3.68097
-      vertex -11.1034 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 1.80494e-06 0.615295 0.788297
-    outer loop
-      vertex -11.2346 4.15224 3.63772
-      vertex -8 4.09682 3.68097
-      vertex -11.1449 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal -6.14946e-07 0.615208 0.788365
-    outer loop
-      vertex -11.3262 4.11691 3.66529
-      vertex -8 4.09682 3.68097
-      vertex -11.2346 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 0 0.615271 0.788316
-    outer loop
-      vertex -8 4.09682 3.68097
-      vertex -11.3262 4.11691 3.66529
-      vertex -11.387 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal 0 0.615233 0.788346
-    outer loop
-      vertex 8 4.09682 3.68097
-      vertex 11.1034 4.2129 3.59038
-      vertex 8 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 6.52341e-06 0.615124 0.78843
-    outer loop
-      vertex 11.1034 4.2129 3.59038
-      vertex 8 4.09682 3.68097
-      vertex 11.1449 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal -1.80494e-06 0.615295 0.788297
-    outer loop
-      vertex 11.1449 4.19202 3.60667
-      vertex 8 4.09682 3.68097
-      vertex 11.2346 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 6.14946e-07 0.615208 0.788365
-    outer loop
-      vertex 11.2346 4.15224 3.63772
-      vertex 8 4.09682 3.68097
-      vertex 11.3262 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal 0 0.615271 0.788316
-    outer loop
-      vertex 11.3262 4.11691 3.66529
-      vertex 8 4.09682 3.68097
-      vertex 11.387 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal 0 0.615233 0.788346
-    outer loop
-      vertex -16 4.09682 3.68097
-      vertex -12.8966 4.2129 3.59038
-      vertex -16 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 6.52341e-06 0.615124 0.78843
-    outer loop
-      vertex -12.8966 4.2129 3.59038
-      vertex -16 4.09682 3.68097
-      vertex -12.8551 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal -1.80494e-06 0.615295 0.788297
-    outer loop
-      vertex -12.8551 4.19202 3.60667
-      vertex -16 4.09682 3.68097
-      vertex -12.7654 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 6.14946e-07 0.615208 0.788365
-    outer loop
-      vertex -12.7654 4.15224 3.63772
-      vertex -16 4.09682 3.68097
-      vertex -12.6738 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal 0 0.615271 0.788316
-    outer loop
-      vertex -12.6738 4.11691 3.66529
-      vertex -16 4.09682 3.68097
-      vertex -12.613 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal -0 0.615233 0.788346
-    outer loop
-      vertex 12.8966 4.2129 3.59038
-      vertex 16 4.09682 3.68097
-      vertex 16 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal -6.52341e-06 0.615124 0.78843
-    outer loop
-      vertex 12.8551 4.19202 3.60667
-      vertex 16 4.09682 3.68097
-      vertex 12.8966 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 1.80494e-06 0.615295 0.788297
-    outer loop
-      vertex 12.7654 4.15224 3.63772
-      vertex 16 4.09682 3.68097
-      vertex 12.8551 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal -6.14946e-07 0.615208 0.788365
-    outer loop
-      vertex 12.6738 4.11691 3.66529
-      vertex 16 4.09682 3.68097
-      vertex 12.7654 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 0 0.615271 0.788316
-    outer loop
-      vertex 16 4.09682 3.68097
-      vertex 12.6738 4.11691 3.66529
-      vertex 12.613 4.09682 3.68097
-    endloop
-  endfacet
   facet normal -0 0.219152 0.975691
     outer loop
       vertex -10.0877 5.41473 3.05764
@@ -9195,118 +9307,6 @@ solid OpenSCAD_Model
       vertex 16 5.27106 3.08991
       vertex 13.8831 5.32622 3.07752
       vertex 13.8618 5.27106 3.08991
-    endloop
-  endfacet
-  facet normal -0 0.170937 0.985282
-    outer loop
-      vertex -10.0497 5.55981 3.03247
-      vertex -8 5.41473 3.05764
-      vertex -8 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal -9.89476e-07 0.170923 0.985284
-    outer loop
-      vertex -10.0599 5.51404 3.04041
-      vertex -8 5.41473 3.05764
-      vertex -10.0497 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 2.69356e-06 0.170998 0.985271
-    outer loop
-      vertex -10.0861 5.41943 3.05683
-      vertex -8 5.41473 3.05764
-      vertex -10.0599 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal 0 0.169837 0.985472
-    outer loop
-      vertex -8 5.41473 3.05764
-      vertex -10.0861 5.41943 3.05683
-      vertex -10.0877 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal 0 0.170937 0.985282
-    outer loop
-      vertex 8 5.41473 3.05764
-      vertex 10.0497 5.55981 3.03247
-      vertex 8 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 9.89476e-07 0.170923 0.985284
-    outer loop
-      vertex 10.0497 5.55981 3.03247
-      vertex 8 5.41473 3.05764
-      vertex 10.0599 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal -2.69356e-06 0.170998 0.985271
-    outer loop
-      vertex 10.0599 5.51404 3.04041
-      vertex 8 5.41473 3.05764
-      vertex 10.0861 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0 0.169837 0.985472
-    outer loop
-      vertex 10.0861 5.41943 3.05683
-      vertex 8 5.41473 3.05764
-      vertex 10.0877 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal 0 0.170937 0.985282
-    outer loop
-      vertex -16 5.41473 3.05764
-      vertex -13.9503 5.55981 3.03247
-      vertex -16 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 9.89476e-07 0.170923 0.985284
-    outer loop
-      vertex -13.9503 5.55981 3.03247
-      vertex -16 5.41473 3.05764
-      vertex -13.9401 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal -2.69356e-06 0.170998 0.985271
-    outer loop
-      vertex -13.9401 5.51404 3.04041
-      vertex -16 5.41473 3.05764
-      vertex -13.9139 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0 0.169837 0.985472
-    outer loop
-      vertex -13.9139 5.41943 3.05683
-      vertex -16 5.41473 3.05764
-      vertex -13.9123 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal -0 0.170937 0.985282
-    outer loop
-      vertex 13.9503 5.55981 3.03247
-      vertex 16 5.41473 3.05764
-      vertex 16 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal -9.89476e-07 0.170923 0.985284
-    outer loop
-      vertex 13.9401 5.51404 3.04041
-      vertex 16 5.41473 3.05764
-      vertex 13.9503 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 2.69356e-06 0.170998 0.985271
-    outer loop
-      vertex 13.9139 5.41943 3.05683
-      vertex 16 5.41473 3.05764
-      vertex 13.9401 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal 0 0.169837 0.985472
-    outer loop
-      vertex 16 5.41473 3.05764
-      vertex 13.9139 5.41943 3.05683
-      vertex 13.9123 5.41473 3.05764
     endloop
   endfacet
   facet normal -0 0.359875 0.933
@@ -9729,88 +9729,4148 @@ solid OpenSCAD_Model
       vertex 13.1052 4.33329 3.50559
     endloop
   endfacet
-  facet normal 1 -0 0
+  facet normal -0.997293 -0.0735256 0
     outer loop
-      vertex 10 -4 13.21
-      vertex 10 0 0.00999928
-      vertex 10 0 13.21
+      vertex -10.0096 6.19603 0.00999928
+      vertex -10.006 6.1472 3.00361
+      vertex -10.0096 6.19603 3.00722
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 2.94012e-06
+    outer loop
+      vertex -10.0024 6.09813 0.00999928
+      vertex -10.006 6.1472 3.00361
+      vertex -10.0096 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal -0.99732 -0.0731679 0
+    outer loop
+      vertex -10.006 6.1472 3.00361
+      vertex -10.0024 6.09813 0.00999928
+      vertex -10.0024 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal -0.999701 -0.02445 -0
+    outer loop
+      vertex -10 6 3
+      vertex -10.0024 6.09813 0.00999928
+      vertex -10 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 -0.02445 0
+    outer loop
+      vertex -10.0024 6.09813 0.00999928
+      vertex -10 6 3
+      vertex -10.0024 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal -0.9925 -0.122242 0
+    outer loop
+      vertex -10.0096 6.19603 3.00722
+      vertex -10.0216 6.29346 3.01
+      vertex -10.0216 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 -0.122242 -0
+    outer loop
+      vertex -10.0096 6.19603 3.00722
+      vertex -10.0216 6.29346 0.00999928
+      vertex -10.0096 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal -0.992172 -0.121362 -0.0294284
+    outer loop
+      vertex -10.0216 6.29346 3.01
+      vertex -10.0096 6.19603 3.00722
+      vertex -10.0143 6.23378 3.01
+    endloop
+  endfacet
+  facet normal -0.073549 0.997292 0
+    outer loop
+      vertex -11.9019 4.00241 0.00999928
+      vertex -11.804 4.00963 3.75618
+      vertex -11.804 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal -0.073549 0.997292 0
+    outer loop
+      vertex -11.804 4.00963 3.75618
+      vertex -11.9019 4.00241 0.00999928
+      vertex -11.9019 4.00241 3.76241
+    endloop
+  endfacet
+  facet normal -0.49291 0.87008 0
+    outer loop
+      vertex -11.0572 4.23616 0.00999928
+      vertex -10.9718 4.28454 3.53992
+      vertex -10.9718 4.28454 0.00999928
+    endloop
+  endfacet
+  facet normal -0.49291 0.87008 0
+    outer loop
+      vertex -10.9718 4.28454 3.53992
+      vertex -11.0572 4.23616 0.00999928
+      vertex -11.0572 4.23616 3.574
+    endloop
+  endfacet
+  facet normal 0.122356 -0.992486 0
+    outer loop
+      vertex -12.2935 7.97835 0.00999928
+      vertex -12.196 7.99037 3.01
+      vertex -12.2935 7.97835 3.01
+    endloop
+  endfacet
+  facet normal 0.122356 -0.992486 0
+    outer loop
+      vertex -12.196 7.99037 3.01
+      vertex -12.2935 7.97835 0.00999928
+      vertex -12.196 7.99037 0.00999928
+    endloop
+  endfacet
+  facet normal -0.615146 -0.788413 0
+    outer loop
+      vertex -10.8086 7.60641 0.00999928
+      vertex -10.7312 7.54602 3.01
+      vertex -10.8086 7.60641 3.01
+    endloop
+  endfacet
+  facet normal -0.615146 -0.788413 -0
+    outer loop
+      vertex -10.7312 7.54602 3.01
+      vertex -10.8086 7.60641 0.00999928
+      vertex -10.7312 7.54602 0.00999928
+    endloop
+  endfacet
+  facet normal 0.933096 -0.359628 0
+    outer loop
+      vertex -13.8831 6.67378 3.01
+      vertex -13.8478 6.76537 0.00999928
+      vertex -13.8478 6.76537 3.01
+    endloop
+  endfacet
+  facet normal 0.933096 -0.359628 0
+    outer loop
+      vertex -13.8478 6.76537 0.00999928
+      vertex -13.8831 6.67378 3.01
+      vertex -13.8831 6.67378 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 0.615259 0
+    outer loop
+      vertex -10.454 4.73121 0.00999928
+      vertex -10.3936 4.8086 3.24758
+      vertex -10.3936 4.8086 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 0.615259 0
+    outer loop
+      vertex -10.3936 4.8086 3.24758
+      vertex -10.454 4.73121 0.00999928
+      vertex -10.454 4.73121 3.28188
+    endloop
+  endfacet
+  facet normal 0.963729 0.266882 -0
+    outer loop
+      vertex -13.9139 5.41943 0.00999928
+      vertex -13.9401 5.51404 3.04041
+      vertex -13.9139 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0.963729 0.266882 0
+    outer loop
+      vertex -13.9401 5.51404 3.04041
+      vertex -13.9139 5.41943 0.00999928
+      vertex -13.9401 5.51404 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 -0.171135 0
+    outer loop
+      vertex -10.0216 6.29346 0.00999928
+      vertex -10.0384 6.39018 3.01
+      vertex -10.0384 6.39018 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 -0.171135 0
+    outer loop
+      vertex -10.0384 6.39018 3.01
+      vertex -10.0216 6.29346 0.00999928
+      vertex -10.0216 6.29346 3.01
+    endloop
+  endfacet
+  facet normal -0.405401 -0.914139 0
+    outer loop
+      vertex -11.2346 7.84776 0.00999928
+      vertex -11.1449 7.80798 3.01
+      vertex -11.2346 7.84776 3.01
+    endloop
+  endfacet
+  facet normal -0.405401 -0.914139 -0
+    outer loop
+      vertex -11.1449 7.80798 3.01
+      vertex -11.2346 7.84776 0.00999928
+      vertex -11.1449 7.80798 0.00999928
+    endloop
+  endfacet
+  facet normal 0.615146 -0.788413 0
+    outer loop
+      vertex -13.2688 7.54602 0.00999928
+      vertex -13.1914 7.60641 3.01
+      vertex -13.2688 7.54602 3.01
+    endloop
+  endfacet
+  facet normal 0.615146 -0.788413 0
+    outer loop
+      vertex -13.1914 7.60641 3.01
+      vertex -13.2688 7.54602 0.00999928
+      vertex -13.1914 7.60641 0.00999928
+    endloop
+  endfacet
+  facet normal 0.949505 -0.313751 0
+    outer loop
+      vertex -13.9139 6.58057 3.01
+      vertex -13.8831 6.67378 0.00999928
+      vertex -13.8831 6.67378 3.01
+    endloop
+  endfacet
+  facet normal 0.949505 -0.313751 0
+    outer loop
+      vertex -13.8831 6.67378 0.00999928
+      vertex -13.9139 6.58057 3.01
+      vertex -13.9139 6.58057 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844461 0.535616 0
+    outer loop
+      vertex -10.3371 4.88886 0.00999928
+      vertex -10.2845 4.97179 3.18213
+      vertex -10.2845 4.97179 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844461 0.535616 0
+    outer loop
+      vertex -10.2845 4.97179 3.18213
+      vertex -10.3371 4.88886 0.00999928
+      vertex -10.3371 4.88886 3.21412
+    endloop
+  endfacet
+  facet normal 0.073549 0.997292 -0
+    outer loop
+      vertex -12.0981 4.00241 0.00999928
+      vertex -12.196 4.00963 3.75618
+      vertex -12.0981 4.00241 3.76241
+    endloop
+  endfacet
+  facet normal 0.073549 0.997292 0
+    outer loop
+      vertex -12.196 4.00963 3.75618
+      vertex -12.0981 4.00241 0.00999928
+      vertex -12.196 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal -0.933096 -0.359628 0
+    outer loop
+      vertex -10.1169 6.67378 0.00999928
+      vertex -10.1522 6.76537 3.01
+      vertex -10.1522 6.76537 0.00999928
+    endloop
+  endfacet
+  facet normal -0.933096 -0.359628 0
+    outer loop
+      vertex -10.1522 6.76537 3.01
+      vertex -10.1169 6.67378 0.00999928
+      vertex -10.1169 6.67378 3.01
+    endloop
+  endfacet
+  facet normal -0.266719 0.963774 0
+    outer loop
+      vertex -11.514 4.05994 0.00999928
+      vertex -11.4194 4.08612 3.6902
+      vertex -11.4194 4.08612 0.00999928
+    endloop
+  endfacet
+  facet normal -0.266719 0.963774 0
+    outer loop
+      vertex -11.4194 4.08612 3.6902
+      vertex -11.514 4.05994 0.00999928
+      vertex -11.514 4.05994 3.71278
+    endloop
+  endfacet
+  facet normal 0.0245594 -0.999698 0
+    outer loop
+      vertex -12.0981 7.99759 0.00999928
+      vertex -12 8 3.01
+      vertex -12.0981 7.99759 3.01
+    endloop
+  endfacet
+  facet normal 0.0245594 -0.999698 0
+    outer loop
+      vertex -12 8 3.01
+      vertex -12.0981 7.99759 0.00999928
+      vertex -12 8 0.00999928
+    endloop
+  endfacet
+  facet normal 0.914131 0.40542 -0
+    outer loop
+      vertex -13.808 5.14489 0.00999928
+      vertex -13.8478 5.23463 3.09999
+      vertex -13.808 5.14489 3.12482
+    endloop
+  endfacet
+  facet normal 0.914131 0.40542 0
+    outer loop
+      vertex -13.8478 5.23463 3.09999
+      vertex -13.808 5.14489 0.00999928
+      vertex -13.8478 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal 0.932867 0.360221 -2.03672e-05
+    outer loop
+      vertex -13.8478 5.23463 0.00999928
+      vertex -13.8831 5.32622 3.07752
+      vertex -13.8618 5.27106 3.08991
+    endloop
+  endfacet
+  facet normal 0.933445 0.358722 -0
+    outer loop
+      vertex -13.8478 5.23463 0.00999928
+      vertex -13.8618 5.27106 3.08991
+      vertex -13.8478 5.23463 3.09999
+    endloop
+  endfacet
+  facet normal 0.933096 0.359628 0
+    outer loop
+      vertex -13.8831 5.32622 3.07752
+      vertex -13.8478 5.23463 0.00999928
+      vertex -13.8831 5.32622 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449575 -0.893243 0
+    outer loop
+      vertex -11.1449 7.80798 0.00999928
+      vertex -11.0572 7.76384 3.01
+      vertex -11.1449 7.80798 3.01
+    endloop
+  endfacet
+  facet normal -0.449575 -0.893243 -0
+    outer loop
+      vertex -11.0572 7.76384 3.01
+      vertex -11.1449 7.80798 0.00999928
+      vertex -11.0572 7.76384 0.00999928
+    endloop
+  endfacet
+  facet normal 0.359859 0.933007 -0
+    outer loop
+      vertex -12.6738 4.11691 0.00999928
+      vertex -12.7654 4.15224 3.63772
+      vertex -12.6738 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal 0.359859 0.933007 0
+    outer loop
+      vertex -12.7654 4.15224 3.63772
+      vertex -12.6738 4.11691 0.00999928
+      vertex -12.7654 4.15224 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844491 -0.53557 0
+    outer loop
+      vertex -10.2845 7.0282 0.00999928
+      vertex -10.3371 7.11114 3.01
+      vertex -10.3371 7.11114 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844491 -0.53557 0
+    outer loop
+      vertex -10.3371 7.11114 3.01
+      vertex -10.2845 7.0282 0.00999928
+      vertex -10.2845 7.0282 3.01
+    endloop
+  endfacet
+  facet normal 0.359859 -0.933007 0
+    outer loop
+      vertex -12.7654 7.84776 0.00999928
+      vertex -12.6738 7.88309 3.01
+      vertex -12.7654 7.84776 3.01
+    endloop
+  endfacet
+  facet normal 0.359859 -0.933007 0
+    outer loop
+      vertex -12.6738 7.88309 3.01
+      vertex -12.7654 7.84776 0.00999928
+      vertex -12.6738 7.88309 0.00999928
+    endloop
+  endfacet
+  facet normal -0.97572 0.219023 0
+    outer loop
+      vertex -10.0599 5.51404 0.00999928
+      vertex -10.0384 5.60982 3.0263
+      vertex -10.0384 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal -0.975411 0.220393 -4.57252e-05
+    outer loop
+      vertex -10.0384 5.60982 3.0263
+      vertex -10.0599 5.51404 0.00999928
+      vertex -10.0497 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal -0.976056 0.217517 0
+    outer loop
+      vertex -10.0497 5.55981 3.03247
+      vertex -10.0599 5.51404 0.00999928
+      vertex -10.0599 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal 0.653253 0.75714 -0
+    outer loop
+      vertex -13.2688 4.45398 0.00999928
+      vertex -13.2731 4.45769 3.42681
+      vertex -13.2688 4.45398 3.42917
+    endloop
+  endfacet
+  facet normal 0.653344 0.757061 1.9929e-07
+    outer loop
+      vertex -13.2688 4.45398 0.00999928
+      vertex -13.3431 4.5181 3.39259
+      vertex -13.2731 4.45769 3.42681
+    endloop
+  endfacet
+  facet normal 0.653339 0.757066 0
+    outer loop
+      vertex -13.3431 4.5181 3.39259
+      vertex -13.2688 4.45398 0.00999928
+      vertex -13.3431 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal 0.724162 -0.68963 0
+    outer loop
+      vertex -13.4819 7.34312 3.01
+      vertex -13.4142 7.41421 0.00999928
+      vertex -13.4142 7.41421 3.01
+    endloop
+  endfacet
+  facet normal 0.724162 -0.68963 0
+    outer loop
+      vertex -13.4142 7.41421 0.00999928
+      vertex -13.4819 7.34312 3.01
+      vertex -13.4819 7.34312 0.00999928
+    endloop
+  endfacet
+  facet normal -0.49291 -0.87008 0
+    outer loop
+      vertex -11.0572 7.76384 0.00999928
+      vertex -10.9718 7.71546 3.01
+      vertex -11.0572 7.76384 3.01
+    endloop
+  endfacet
+  facet normal -0.49291 -0.87008 -0
+    outer loop
+      vertex -10.9718 7.71546 3.01
+      vertex -11.0572 7.76384 0.00999928
+      vertex -10.9718 7.71546 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817707 -0.575635 0
+    outer loop
+      vertex -10.3371 7.11114 0.00999928
+      vertex -10.3936 7.1914 3.01
+      vertex -10.3936 7.1914 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817707 -0.575635 0
+    outer loop
+      vertex -10.3936 7.1914 3.01
+      vertex -10.3371 7.11114 0.00999928
+      vertex -10.3371 7.11114 3.01
+    endloop
+  endfacet
+  facet normal 0.405401 0.914139 -0
+    outer loop
+      vertex -12.7654 4.15224 0.00999928
+      vertex -12.8551 4.19202 3.60667
+      vertex -12.7654 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0.405401 0.914139 0
+    outer loop
+      vertex -12.8551 4.19202 3.60667
+      vertex -12.7654 4.15224 0.00999928
+      vertex -12.8551 4.19202 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870455 -0.492249 0
+    outer loop
+      vertex -10.2362 6.94279 0.00999928
+      vertex -10.2845 7.0282 3.01
+      vertex -10.2845 7.0282 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870455 -0.492249 0
+    outer loop
+      vertex -10.2845 7.0282 3.01
+      vertex -10.2362 6.94279 0.00999928
+      vertex -10.2362 6.94279 3.01
+    endloop
+  endfacet
+  facet normal -0.122356 -0.992486 0
+    outer loop
+      vertex -11.804 7.99037 0.00999928
+      vertex -11.7065 7.97835 3.01
+      vertex -11.804 7.99037 3.01
+    endloop
+  endfacet
+  facet normal -0.122356 -0.992486 -0
+    outer loop
+      vertex -11.7065 7.97835 3.01
+      vertex -11.804 7.99037 0.00999928
+      vertex -11.7065 7.97835 0.00999928
+    endloop
+  endfacet
+  facet normal 0.946665 0.322219 -0.000287769
+    outer loop
+      vertex -13.8831 5.32622 0.00999928
+      vertex -13.9139 5.41943 3.05683
+      vertex -13.9123 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal 0.949655 0.313297 -0
+    outer loop
+      vertex -13.8831 5.32622 0.00999928
+      vertex -13.9123 5.41473 3.05764
+      vertex -13.8831 5.32622 3.07752
+    endloop
+  endfacet
+  facet normal 0.949505 0.313751 0
+    outer loop
+      vertex -13.9139 5.41943 3.05683
+      vertex -13.8831 5.32622 0.00999928
+      vertex -13.9139 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal -0.405401 0.914139 0
+    outer loop
+      vertex -11.2346 4.15224 0.00999928
+      vertex -11.1449 4.19202 3.60667
+      vertex -11.1449 4.19202 0.00999928
+    endloop
+  endfacet
+  facet normal -0.405401 0.914139 0
+    outer loop
+      vertex -11.1449 4.19202 3.60667
+      vertex -11.2346 4.15224 0.00999928
+      vertex -11.2346 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0.893739 0.448588 5.49163e-05
+    outer loop
+      vertex -13.7638 5.05721 0.00999928
+      vertex -13.808 5.14489 3.12482
+      vertex -13.8001 5.12915 3.12918
+    endloop
+  endfacet
+  facet normal 0.892783 0.450487 -0
+    outer loop
+      vertex -13.7638 5.05721 0.00999928
+      vertex -13.8001 5.12915 3.12918
+      vertex -13.7638 5.05721 3.15294
+    endloop
+  endfacet
+  facet normal 0.892956 0.450144 0
+    outer loop
+      vertex -13.808 5.14489 3.12482
+      vertex -13.7638 5.05721 0.00999928
+      vertex -13.808 5.14489 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244476 0
+    outer loop
+      vertex -10.0024 5.90186 0.00999928
+      vertex -10 6 3
+      vertex -10 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244476 0
+    outer loop
+      vertex -10 6 3
+      vertex -10.0024 5.90186 0.00999928
+      vertex -10.0024 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal -0.892956 -0.450144 0
+    outer loop
+      vertex -10.192 6.85511 0.00999928
+      vertex -10.2362 6.94279 3.01
+      vertex -10.2362 6.94279 0.00999928
+    endloop
+  endfacet
+  facet normal -0.892956 -0.450144 0
+    outer loop
+      vertex -10.2362 6.94279 3.01
+      vertex -10.192 6.85511 0.00999928
+      vertex -10.192 6.85511 3.01
+    endloop
+  endfacet
+  facet normal -0.997319 0.0731828 0
+    outer loop
+      vertex -10.0024 5.90186 0.00999928
+      vertex -10.006 5.8528 3.00361
+      vertex -10.0024 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal -0.997306 0.0733538 2.8179e-06
+    outer loop
+      vertex -10.0096 5.80397 0.00999928
+      vertex -10.006 5.8528 3.00361
+      vertex -10.0024 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal -0.997293 0.0735256 0
+    outer loop
+      vertex -10.006 5.8528 3.00361
+      vertex -10.0096 5.80397 0.00999928
+      vertex -10.0096 5.80397 3.00722
+    endloop
+  endfacet
+  facet normal 0.689525 -0.724261 0
+    outer loop
+      vertex -13.4142 7.41421 0.00999928
+      vertex -13.3431 7.4819 3.01
+      vertex -13.4142 7.41421 3.01
+    endloop
+  endfacet
+  facet normal 0.689525 -0.724261 0
+    outer loop
+      vertex -13.3431 7.4819 3.01
+      vertex -13.4142 7.41421 0.00999928
+      vertex -13.3431 7.4819 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 0.933007 0
+    outer loop
+      vertex -11.3262 4.11691 0.00999928
+      vertex -11.2346 4.15224 3.63772
+      vertex -11.2346 4.15224 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 0.933007 0
+    outer loop
+      vertex -11.2346 4.15224 3.63772
+      vertex -11.3262 4.11691 0.00999928
+      vertex -11.3262 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal -0.653339 -0.757066 0
+    outer loop
+      vertex -10.7312 7.54602 0.00999928
+      vertex -10.6569 7.4819 3.01
+      vertex -10.7312 7.54602 3.01
+    endloop
+  endfacet
+  facet normal -0.653339 -0.757066 -0
+    outer loop
+      vertex -10.6569 7.4819 3.01
+      vertex -10.7312 7.54602 0.00999928
+      vertex -10.6569 7.4819 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449575 0.893243 0
+    outer loop
+      vertex -11.1449 4.19202 0.00999928
+      vertex -11.0572 4.23616 3.574
+      vertex -11.0572 4.23616 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449686 0.893187 3.40941e-06
+    outer loop
+      vertex -11.0572 4.23616 3.574
+      vertex -11.1449 4.19202 0.00999928
+      vertex -11.1034 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal -0.449451 0.893305 0
+    outer loop
+      vertex -11.1034 4.2129 3.59038
+      vertex -11.1449 4.19202 0.00999928
+      vertex -11.1449 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal 0.724066 0.68973 -4.12488e-06
+    outer loop
+      vertex -13.4142 4.58579 0.00999928
+      vertex -13.4819 4.65688 3.31846
+      vertex -13.4142 4.58581 3.35424
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 10 0 0.00999928
-      vertex 10 -4 13.21
-      vertex 10 -4 0.00999928
+      vertex -13.4142 4.58579 0.00999928
+      vertex -13.4142 4.58581 3.35424
+      vertex -13.4142 4.58579 3.35425
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.724162 0.68963 0
     outer loop
-      vertex -10 0 13.21
-      vertex 10 -4 13.21
-      vertex 10 0 13.21
+      vertex -13.4819 4.65688 3.31846
+      vertex -13.4142 4.58579 0.00999928
+      vertex -13.4819 4.65688 0.00999928
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.266719 0.963774 -0
     outer loop
-      vertex 10 -4 13.21
-      vertex -10 0 13.21
-      vertex -10 -4 13.21
+      vertex -12.486 4.05994 0.00999928
+      vertex -12.5806 4.08612 3.6902
+      vertex -12.486 4.05994 3.71278
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal 0.266719 0.963774 0
     outer loop
-      vertex -10 -4 0.00999928
-      vertex -10 0 13.21
-      vertex -10 0 0.00999928
+      vertex -12.5806 4.08612 3.6902
+      vertex -12.486 4.05994 0.00999928
+      vertex -12.5806 4.08612 0.00999928
+    endloop
+  endfacet
+  facet normal -0.757297 -0.653071 0
+    outer loop
+      vertex -10.454 7.26879 0.00999928
+      vertex -10.5181 7.34312 3.01
+      vertex -10.5181 7.34312 0.00999928
+    endloop
+  endfacet
+  facet normal -0.757297 -0.653071 0
+    outer loop
+      vertex -10.5181 7.34312 3.01
+      vertex -10.454 7.26879 0.00999928
+      vertex -10.454 7.26879 3.01
+    endloop
+  endfacet
+  facet normal -0.788325 -0.615259 0
+    outer loop
+      vertex -10.3936 7.1914 0.00999928
+      vertex -10.454 7.26879 3.01
+      vertex -10.454 7.26879 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 -0.615259 0
+    outer loop
+      vertex -10.454 7.26879 3.01
+      vertex -10.3936 7.1914 0.00999928
+      vertex -10.3936 7.1914 3.01
+    endloop
+  endfacet
+  facet normal 0.999701 0.0244476 -0
+    outer loop
+      vertex -13.9976 5.90186 0.00999928
+      vertex -14 6 3
+      vertex -13.9976 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal 0.999701 0.0244476 0
+    outer loop
+      vertex -14 6 3
+      vertex -13.9976 5.90186 0.00999928
+      vertex -14 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.575647 -0.817698 0
+    outer loop
+      vertex -10.8889 7.66294 0.00999928
+      vertex -10.8086 7.60641 3.01
+      vertex -10.8889 7.66294 3.01
+    endloop
+  endfacet
+  facet normal -0.575647 -0.817698 -0
+    outer loop
+      vertex -10.8086 7.60641 3.01
+      vertex -10.8889 7.66294 0.00999928
+      vertex -10.8086 7.60641 0.00999928
+    endloop
+  endfacet
+  facet normal 0.914131 -0.40542 0
+    outer loop
+      vertex -13.8478 6.76537 3.01
+      vertex -13.808 6.85511 0.00999928
+      vertex -13.808 6.85511 3.01
+    endloop
+  endfacet
+  facet normal 0.914131 -0.40542 0
+    outer loop
+      vertex -13.808 6.85511 0.00999928
+      vertex -13.8478 6.76537 3.01
+      vertex -13.8478 6.76537 0.00999928
+    endloop
+  endfacet
+  facet normal -0.219076 -0.975708 0
+    outer loop
+      vertex -11.6098 7.96157 0.00999928
+      vertex -11.514 7.94006 3.01
+      vertex -11.6098 7.96157 3.01
+    endloop
+  endfacet
+  facet normal -0.219076 -0.975708 -0
+    outer loop
+      vertex -11.514 7.94006 3.01
+      vertex -11.6098 7.96157 0.00999928
+      vertex -11.514 7.94006 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 0.122242 0
+    outer loop
+      vertex -10.0216 5.70654 0.00999928
+      vertex -10.0096 5.80397 3.00722
+      vertex -10.0096 5.80397 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 0.122242 0
+    outer loop
+      vertex -10.0096 5.80397 3.00722
+      vertex -10.0216 5.70654 0.00999928
+      vertex -10.0216 5.70654 3.0144
+    endloop
+  endfacet
+  facet normal 0.997293 -0.0735256 0
+    outer loop
+      vertex -13.994 6.1472 3.00361
+      vertex -13.9904 6.19603 0.00999928
+      vertex -13.9904 6.19603 3.00722
+    endloop
+  endfacet
+  facet normal 0.99732 -0.0731681 5.86359e-06
+    outer loop
+      vertex -13.9976 6.09813 3.00241
+      vertex -13.9904 6.19603 0.00999928
+      vertex -13.994 6.1472 3.00361
+    endloop
+  endfacet
+  facet normal 0.997307 -0.0733463 0
+    outer loop
+      vertex -13.9904 6.19603 0.00999928
+      vertex -13.9976 6.09813 3.00241
+      vertex -13.9976 6.09813 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724162 0.68963 0
+    outer loop
+      vertex -10.5858 4.58579 0.00999928
+      vertex -10.5181 4.65688 3.31846
+      vertex -10.5181 4.65688 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724066 0.68973 -4.12488e-06
+    outer loop
+      vertex -10.5181 4.65688 3.31846
+      vertex -10.5858 4.58579 0.00999928
+      vertex -10.5858 4.58581 3.35424
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -10 0 13.21
-      vertex -10 -4 0.00999928
-      vertex -10 -4 13.21
+      vertex -10.5858 4.58581 3.35424
+      vertex -10.5858 4.58579 0.00999928
+      vertex -10.5858 4.58579 3.35425
+    endloop
+  endfacet
+  facet normal 0.31369 -0.949526 0
+    outer loop
+      vertex -12.6738 7.88309 0.00999928
+      vertex -12.5806 7.91388 3.01
+      vertex -12.6738 7.88309 3.01
+    endloop
+  endfacet
+  facet normal 0.31369 -0.949526 0
+    outer loop
+      vertex -12.5806 7.91388 3.01
+      vertex -12.6738 7.88309 0.00999928
+      vertex -12.5806 7.91388 0.00999928
+    endloop
+  endfacet
+  facet normal 0.817534 0.575881 -9.2087e-06
+    outer loop
+      vertex -13.6064 4.8086 0.00999928
+      vertex -13.6629 4.88886 3.21412
+      vertex -13.6369 4.85195 3.22836
+    endloop
+  endfacet
+  facet normal 0.817856 0.575423 -0
+    outer loop
+      vertex -13.6064 4.8086 0.00999928
+      vertex -13.6369 4.85195 3.22836
+      vertex -13.6064 4.8086 3.24758
+    endloop
+  endfacet
+  facet normal 0.817707 0.575635 0
+    outer loop
+      vertex -13.6629 4.88886 3.21412
+      vertex -13.6064 4.8086 0.00999928
+      vertex -13.6629 4.88886 0.00999928
+    endloop
+  endfacet
+  facet normal 0.985937 0.167119 0.000133127
+    outer loop
+      vertex -13.9616 5.60982 0.00999928
+      vertex -13.9784 5.70654 3.0144
+      vertex -13.9783 5.70595 3.01445
+    endloop
+  endfacet
+  facet normal 0.985243 0.17116 -0
+    outer loop
+      vertex -13.9616 5.60982 0.00999928
+      vertex -13.9783 5.70595 3.01445
+      vertex -13.9616 5.60982 3.0263
+    endloop
+  endfacet
+  facet normal 0.985248 0.171135 0
+    outer loop
+      vertex -13.9784 5.70654 3.0144
+      vertex -13.9616 5.60982 0.00999928
+      vertex -13.9784 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal -0.689525 0.724261 0
+    outer loop
+      vertex -10.6569 4.5181 0.00999928
+      vertex -10.5858 4.58579 3.35425
+      vertex -10.5858 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal -0.689525 0.724261 0
+    outer loop
+      vertex -10.5858 4.58579 3.35425
+      vertex -10.6569 4.5181 0.00999928
+      vertex -10.6569 4.5181 3.39259
+    endloop
+  endfacet
+  facet normal -0.97572 -0.219023 0
+    outer loop
+      vertex -10.0384 6.39018 0.00999928
+      vertex -10.0599 6.48596 3.01
+      vertex -10.0599 6.48596 0.00999928
+    endloop
+  endfacet
+  facet normal -0.97572 -0.219023 0
+    outer loop
+      vertex -10.0599 6.48596 3.01
+      vertex -10.0384 6.39018 0.00999928
+      vertex -10.0384 6.39018 3.01
+    endloop
+  endfacet
+  facet normal 0.9925 0.122242 -0
+    outer loop
+      vertex -13.9784 5.70654 0.00999928
+      vertex -13.9904 5.80397 3.00722
+      vertex -13.9784 5.70654 3.0144
+    endloop
+  endfacet
+  facet normal 0.9925 0.122242 0
+    outer loop
+      vertex -13.9904 5.80397 3.00722
+      vertex -13.9784 5.70654 0.00999928
+      vertex -13.9904 5.80397 0.00999928
+    endloop
+  endfacet
+  facet normal 0.122356 0.992486 -0
+    outer loop
+      vertex -12.196 4.00963 0.00999928
+      vertex -12.2935 4.02165 3.74581
+      vertex -12.196 4.00963 3.75618
+    endloop
+  endfacet
+  facet normal 0.122356 0.992486 0
+    outer loop
+      vertex -12.2935 4.02165 3.74581
+      vertex -12.196 4.00963 0.00999928
+      vertex -12.2935 4.02165 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 -0.933007 0
+    outer loop
+      vertex -11.3262 7.88309 0.00999928
+      vertex -11.2346 7.84776 3.01
+      vertex -11.3262 7.88309 3.01
+    endloop
+  endfacet
+  facet normal -0.359859 -0.933007 -0
+    outer loop
+      vertex -11.2346 7.84776 3.01
+      vertex -11.3262 7.88309 0.00999928
+      vertex -11.2346 7.84776 0.00999928
+    endloop
+  endfacet
+  facet normal -0.0245594 0.999698 0
+    outer loop
+      vertex -12 4 0.00999928
+      vertex -11.9019 4.00241 3.76241
+      vertex -11.9019 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal -0.0245594 0.999698 0
+    outer loop
+      vertex -11.9019 4.00241 3.76241
+      vertex -12 4 0.00999928
+      vertex -12 4 3.76449
+    endloop
+  endfacet
+  facet normal 0.870455 -0.492249 0
+    outer loop
+      vertex -13.7638 6.94279 3.01
+      vertex -13.7155 7.0282 0.00999928
+      vertex -13.7155 7.0282 3.01
+    endloop
+  endfacet
+  facet normal 0.870455 -0.492249 0
+    outer loop
+      vertex -13.7155 7.0282 0.00999928
+      vertex -13.7638 6.94279 3.01
+      vertex -13.7638 6.94279 0.00999928
+    endloop
+  endfacet
+  facet normal 0.615209 0.788364 -0
+    outer loop
+      vertex -13.1914 4.39358 0.00999928
+      vertex -13.2688 4.45398 3.42917
+      vertex -13.1914 4.39358 3.46741
+    endloop
+  endfacet
+  facet normal 0.615209 0.788364 0
+    outer loop
+      vertex -13.2688 4.45398 3.42917
+      vertex -13.1914 4.39358 0.00999928
+      vertex -13.2688 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal -0.122356 0.992486 0
+    outer loop
+      vertex -11.804 4.00963 0.00999928
+      vertex -11.7065 4.02165 3.74581
+      vertex -11.7065 4.02165 0.00999928
+    endloop
+  endfacet
+  facet normal -0.122356 0.992486 0
+    outer loop
+      vertex -11.7065 4.02165 3.74581
+      vertex -11.804 4.00963 0.00999928
+      vertex -11.804 4.00963 3.75618
+    endloop
+  endfacet
+  facet normal 0.49291 -0.87008 0
+    outer loop
+      vertex -13.0282 7.71546 0.00999928
+      vertex -12.9428 7.76384 3.01
+      vertex -13.0282 7.71546 3.01
+    endloop
+  endfacet
+  facet normal 0.49291 -0.87008 0
+    outer loop
+      vertex -12.9428 7.76384 3.01
+      vertex -13.0282 7.71546 0.00999928
+      vertex -12.9428 7.76384 0.00999928
+    endloop
+  endfacet
+  facet normal -0.535173 -0.844742 0
+    outer loop
+      vertex -10.9718 7.71546 0.00999928
+      vertex -10.8889 7.66294 3.01
+      vertex -10.9718 7.71546 3.01
+    endloop
+  endfacet
+  facet normal -0.535173 -0.844742 -0
+    outer loop
+      vertex -10.8889 7.66294 3.01
+      vertex -10.9718 7.71546 0.00999928
+      vertex -10.8889 7.66294 0.00999928
+    endloop
+  endfacet
+  facet normal -0.949505 -0.313751 0
+    outer loop
+      vertex -10.0861 6.58057 0.00999928
+      vertex -10.1169 6.67378 3.01
+      vertex -10.1169 6.67378 0.00999928
+    endloop
+  endfacet
+  facet normal -0.949505 -0.313751 0
+    outer loop
+      vertex -10.1169 6.67378 3.01
+      vertex -10.0861 6.58057 0.00999928
+      vertex -10.0861 6.58057 3.01
+    endloop
+  endfacet
+  facet normal -0.870479 0.492205 0
+    outer loop
+      vertex -10.2845 4.97179 0.00999928
+      vertex -10.2362 5.05721 3.15294
+      vertex -10.2362 5.05721 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870382 0.492377 -6.16218e-06
+    outer loop
+      vertex -10.2362 5.05721 3.15294
+      vertex -10.2845 4.97179 0.00999928
+      vertex -10.2746 4.98933 3.17537
+    endloop
+  endfacet
+  facet normal -0.870859 0.491534 0
+    outer loop
+      vertex -10.2746 4.98933 3.17537
+      vertex -10.2845 4.97179 0.00999928
+      vertex -10.2845 4.97179 3.18213
+    endloop
+  endfacet
+  facet normal 0.534922 0.844902 -0
+    outer loop
+      vertex -13.0282 4.28454 0.00999928
+      vertex -13.1052 4.33329 3.50559
+      vertex -13.0282 4.28454 3.53992
+    endloop
+  endfacet
+  facet normal 0.538415 0.84268 0.000107927
+    outer loop
+      vertex -13.0282 4.28454 0.00999928
+      vertex -13.1111 4.33706 3.5032
+      vertex -13.1052 4.33329 3.50559
+    endloop
+  endfacet
+  facet normal 0.535173 0.844742 0
+    outer loop
+      vertex -13.1111 4.33706 3.5032
+      vertex -13.0282 4.28454 0.00999928
+      vertex -13.1111 4.33706 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 -0.266882 0
+    outer loop
+      vertex -10.0599 6.48596 0.00999928
+      vertex -10.0861 6.58057 3.01
+      vertex -10.0861 6.58057 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 -0.266882 0
+    outer loop
+      vertex -10.0861 6.58057 3.01
+      vertex -10.0599 6.48596 0.00999928
+      vertex -10.0599 6.48596 3.01
+    endloop
+  endfacet
+  facet normal 0.756488 0.654008 -3.71393e-05
+    outer loop
+      vertex -13.4819 4.65688 0.00999928
+      vertex -13.546 4.73121 3.28188
+      vertex -13.534 4.71733 3.28803
+    endloop
+  endfacet
+  facet normal 0.757485 0.652853 -0
+    outer loop
+      vertex -13.4819 4.65688 0.00999928
+      vertex -13.534 4.71733 3.28803
+      vertex -13.4819 4.65688 3.31846
+    endloop
+  endfacet
+  facet normal 0.757297 0.653071 0
+    outer loop
+      vertex -13.546 4.73121 3.28188
+      vertex -13.4819 4.65688 0.00999928
+      vertex -13.546 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 0.266882 0
+    outer loop
+      vertex -10.0861 5.41943 0.00999928
+      vertex -10.0599 5.51404 3.04041
+      vertex -10.0599 5.51404 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 0.266882 0
+    outer loop
+      vertex -10.0599 5.51404 3.04041
+      vertex -10.0861 5.41943 0.00999928
+      vertex -10.0861 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0.963729 -0.266882 0
+    outer loop
+      vertex -13.9401 6.48596 3.01
+      vertex -13.9139 6.58057 0.00999928
+      vertex -13.9139 6.58057 3.01
+    endloop
+  endfacet
+  facet normal 0.963729 -0.266882 0
+    outer loop
+      vertex -13.9139 6.58057 0.00999928
+      vertex -13.9401 6.48596 3.01
+      vertex -13.9401 6.48596 0.00999928
+    endloop
+  endfacet
+  facet normal 0.449575 -0.893243 0
+    outer loop
+      vertex -12.9428 7.76384 0.00999928
+      vertex -12.8551 7.80798 3.01
+      vertex -12.9428 7.76384 3.01
+    endloop
+  endfacet
+  facet normal 0.449575 -0.893243 0
+    outer loop
+      vertex -12.8551 7.80798 3.01
+      vertex -12.9428 7.76384 0.00999928
+      vertex -12.8551 7.80798 0.00999928
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -10.8086 4.39358 0.00999928
+      vertex -10.7312 4.45398 3.42917
+      vertex -10.7312 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex -10.7312 4.45398 3.42917
+      vertex -10.8086 4.39358 0.00999928
+      vertex -10.8086 4.39358 3.46741
+    endloop
+  endfacet
+  facet normal -0.757297 0.653071 0
+    outer loop
+      vertex -10.5181 4.65688 0.00999928
+      vertex -10.454 4.73121 3.28188
+      vertex -10.454 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal -0.756488 0.654008 -3.71393e-05
+    outer loop
+      vertex -10.454 4.73121 3.28188
+      vertex -10.5181 4.65688 0.00999928
+      vertex -10.466 4.71733 3.28803
+    endloop
+  endfacet
+  facet normal -0.757485 0.652853 0
+    outer loop
+      vertex -10.466 4.71733 3.28803
+      vertex -10.5181 4.65688 0.00999928
+      vertex -10.5181 4.65688 3.31846
+    endloop
+  endfacet
+  facet normal 0.170971 -0.985276 0
+    outer loop
+      vertex -12.3902 7.96157 0.00999928
+      vertex -12.2935 7.97835 3.01
+      vertex -12.3902 7.96157 3.01
+    endloop
+  endfacet
+  facet normal 0.170971 -0.985276 0
+    outer loop
+      vertex -12.2935 7.97835 3.01
+      vertex -12.3902 7.96157 0.00999928
+      vertex -12.2935 7.97835 0.00999928
+    endloop
+  endfacet
+  facet normal 0.892956 -0.450144 0
+    outer loop
+      vertex -13.808 6.85511 3.01
+      vertex -13.7638 6.94279 0.00999928
+      vertex -13.7638 6.94279 3.01
+    endloop
+  endfacet
+  facet normal 0.892956 -0.450144 0
+    outer loop
+      vertex -13.7638 6.94279 0.00999928
+      vertex -13.808 6.85511 3.01
+      vertex -13.808 6.85511 0.00999928
+    endloop
+  endfacet
+  facet normal 0.992172 -0.121362 -0.0294284
+    outer loop
+      vertex -13.9904 6.19603 3.00722
+      vertex -13.9784 6.29346 3.01
+      vertex -13.9857 6.23378 3.01
+    endloop
+  endfacet
+  facet normal 0.9925 -0.122242 0
+    outer loop
+      vertex -13.9784 6.29346 3.01
+      vertex -13.9904 6.19603 3.00722
+      vertex -13.9784 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal 0.9925 -0.122242 0
+    outer loop
+      vertex -13.9784 6.29346 0.00999928
+      vertex -13.9904 6.19603 3.00722
+      vertex -13.9904 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal 0.653339 -0.757066 0
+    outer loop
+      vertex -13.3431 7.4819 0.00999928
+      vertex -13.2688 7.54602 3.01
+      vertex -13.3431 7.4819 3.01
+    endloop
+  endfacet
+  facet normal 0.653339 -0.757066 0
+    outer loop
+      vertex -13.2688 7.54602 3.01
+      vertex -13.3431 7.4819 0.00999928
+      vertex -13.2688 7.54602 0.00999928
+    endloop
+  endfacet
+  facet normal -0.653339 0.757066 0
+    outer loop
+      vertex -10.7312 4.45398 0.00999928
+      vertex -10.6569 4.5181 3.39259
+      vertex -10.6569 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal -0.653344 0.757061 1.9929e-07
+    outer loop
+      vertex -10.6569 4.5181 3.39259
+      vertex -10.7312 4.45398 0.00999928
+      vertex -10.7269 4.45769 3.42681
+    endloop
+  endfacet
+  facet normal -0.653253 0.75714 0
+    outer loop
+      vertex -10.7269 4.45769 3.42681
+      vertex -10.7312 4.45398 0.00999928
+      vertex -10.7312 4.45398 3.42917
+    endloop
+  endfacet
+  facet normal -0.949505 0.313751 0
+    outer loop
+      vertex -10.1169 5.32622 0.00999928
+      vertex -10.0861 5.41943 3.05683
+      vertex -10.0861 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal -0.946665 0.322219 -0.000287769
+    outer loop
+      vertex -10.0861 5.41943 3.05683
+      vertex -10.1169 5.32622 0.00999928
+      vertex -10.0877 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal -0.949655 0.313297 0
+    outer loop
+      vertex -10.0877 5.41473 3.05764
+      vertex -10.1169 5.32622 0.00999928
+      vertex -10.1169 5.32622 3.07752
+    endloop
+  endfacet
+  facet normal -0.724162 -0.68963 0
+    outer loop
+      vertex -10.5181 7.34312 0.00999928
+      vertex -10.5858 7.41421 3.01
+      vertex -10.5858 7.41421 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724162 -0.68963 0
+    outer loop
+      vertex -10.5858 7.41421 3.01
+      vertex -10.5181 7.34312 0.00999928
+      vertex -10.5181 7.34312 3.01
+    endloop
+  endfacet
+  facet normal 0.073549 -0.997292 0
+    outer loop
+      vertex -12.196 7.99037 0.00999928
+      vertex -12.0981 7.99759 3.01
+      vertex -12.196 7.99037 3.01
+    endloop
+  endfacet
+  facet normal 0.073549 -0.997292 0
+    outer loop
+      vertex -12.0981 7.99759 3.01
+      vertex -12.196 7.99037 0.00999928
+      vertex -12.0981 7.99759 0.00999928
+    endloop
+  endfacet
+  facet normal 0.997319 0.0731828 0
+    outer loop
+      vertex -13.994 5.8528 3.00361
+      vertex -13.9976 5.90186 0.00999928
+      vertex -13.9976 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal 0.997293 0.0735256 -0
+    outer loop
+      vertex -13.9904 5.80397 0.00999928
+      vertex -13.994 5.8528 3.00361
+      vertex -13.9904 5.80397 3.00722
+    endloop
+  endfacet
+  facet normal 0.997306 0.0733538 2.8179e-06
+    outer loop
+      vertex -13.994 5.8528 3.00361
+      vertex -13.9904 5.80397 0.00999928
+      vertex -13.9976 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817707 0.575635 0
+    outer loop
+      vertex -10.3936 4.8086 0.00999928
+      vertex -10.3371 4.88886 3.21412
+      vertex -10.3371 4.88886 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817534 0.575881 -9.2087e-06
+    outer loop
+      vertex -10.3371 4.88886 3.21412
+      vertex -10.3936 4.8086 0.00999928
+      vertex -10.3631 4.85195 3.22836
+    endloop
+  endfacet
+  facet normal -0.817856 0.575423 0
+    outer loop
+      vertex -10.3631 4.85195 3.22836
+      vertex -10.3936 4.8086 0.00999928
+      vertex -10.3936 4.8086 3.24758
+    endloop
+  endfacet
+  facet normal -0.689525 -0.724261 0
+    outer loop
+      vertex -10.6569 7.4819 0.00999928
+      vertex -10.5858 7.41421 3.01
+      vertex -10.6569 7.4819 3.01
+    endloop
+  endfacet
+  facet normal -0.689525 -0.724261 -0
+    outer loop
+      vertex -10.5858 7.41421 3.01
+      vertex -10.6569 7.4819 0.00999928
+      vertex -10.5858 7.41421 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 0.985276 0
+    outer loop
+      vertex -11.7065 4.02165 0.00999928
+      vertex -11.6098 4.03843 3.73134
+      vertex -11.6098 4.03843 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 0.985276 0
+    outer loop
+      vertex -11.6098 4.03843 3.73134
+      vertex -11.7065 4.02165 0.00999928
+      vertex -11.7065 4.02165 3.74581
+    endloop
+  endfacet
+  facet normal -0.892956 0.450144 0
+    outer loop
+      vertex -10.2362 5.05721 0.00999928
+      vertex -10.192 5.14489 3.12482
+      vertex -10.192 5.14489 0.00999928
+    endloop
+  endfacet
+  facet normal -0.893739 0.448588 5.49163e-05
+    outer loop
+      vertex -10.192 5.14489 3.12482
+      vertex -10.2362 5.05721 0.00999928
+      vertex -10.1999 5.12915 3.12918
+    endloop
+  endfacet
+  facet normal -0.892783 0.450487 0
+    outer loop
+      vertex -10.1999 5.12915 3.12918
+      vertex -10.2362 5.05721 0.00999928
+      vertex -10.2362 5.05721 3.15294
+    endloop
+  endfacet
+  facet normal 0.757297 -0.653071 0
+    outer loop
+      vertex -13.546 7.26879 3.01
+      vertex -13.4819 7.34312 0.00999928
+      vertex -13.4819 7.34312 3.01
+    endloop
+  endfacet
+  facet normal 0.757297 -0.653071 0
+    outer loop
+      vertex -13.4819 7.34312 0.00999928
+      vertex -13.546 7.26879 3.01
+      vertex -13.546 7.26879 0.00999928
+    endloop
+  endfacet
+  facet normal -0.575579 0.817746 0
+    outer loop
+      vertex -10.8889 4.33706 0.00999928
+      vertex -10.8086 4.39358 3.46741
+      vertex -10.8086 4.39358 0.00999928
+    endloop
+  endfacet
+  facet normal -0.575579 0.817746 0
+    outer loop
+      vertex -10.8086 4.39358 3.46741
+      vertex -10.8889 4.33706 0.00999928
+      vertex -10.8889 4.33706 3.5032
+    endloop
+  endfacet
+  facet normal 0.689525 0.724261 -0
+    outer loop
+      vertex -13.3431 4.5181 0.00999928
+      vertex -13.4142 4.58579 3.35425
+      vertex -13.3431 4.5181 3.39259
+    endloop
+  endfacet
+  facet normal 0.689525 0.724261 0
+    outer loop
+      vertex -13.4142 4.58579 3.35425
+      vertex -13.3431 4.5181 0.00999928
+      vertex -13.4142 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal -0.219076 0.975708 0
+    outer loop
+      vertex -11.6098 4.03843 0.00999928
+      vertex -11.514 4.05994 3.71278
+      vertex -11.514 4.05994 0.00999928
+    endloop
+  endfacet
+  facet normal -0.219076 0.975708 0
+    outer loop
+      vertex -11.514 4.05994 3.71278
+      vertex -11.6098 4.03843 0.00999928
+      vertex -11.6098 4.03843 3.73134
+    endloop
+  endfacet
+  facet normal -0.914131 -0.40542 0
+    outer loop
+      vertex -10.1522 6.76537 0.00999928
+      vertex -10.192 6.85511 3.01
+      vertex -10.192 6.85511 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 -0.40542 0
+    outer loop
+      vertex -10.192 6.85511 3.01
+      vertex -10.1522 6.76537 0.00999928
+      vertex -10.1522 6.76537 3.01
+    endloop
+  endfacet
+  facet normal 0.170971 0.985276 -0
+    outer loop
+      vertex -12.2935 4.02165 0.00999928
+      vertex -12.3902 4.03843 3.73134
+      vertex -12.2935 4.02165 3.74581
+    endloop
+  endfacet
+  facet normal 0.170971 0.985276 0
+    outer loop
+      vertex -12.3902 4.03843 3.73134
+      vertex -12.2935 4.02165 0.00999928
+      vertex -12.3902 4.03843 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 0.171135 0
+    outer loop
+      vertex -10.0384 5.60982 0.00999928
+      vertex -10.0216 5.70654 3.0144
+      vertex -10.0216 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985937 0.167119 0.000133127
+    outer loop
+      vertex -10.0216 5.70654 3.0144
+      vertex -10.0384 5.60982 0.00999928
+      vertex -10.0217 5.70595 3.01445
+    endloop
+  endfacet
+  facet normal -0.985243 0.17116 0
+    outer loop
+      vertex -10.0217 5.70595 3.01445
+      vertex -10.0384 5.60982 0.00999928
+      vertex -10.0384 5.60982 3.0263
+    endloop
+  endfacet
+  facet normal 0.817707 -0.575635 0
+    outer loop
+      vertex -13.6629 7.11114 3.01
+      vertex -13.6064 7.1914 0.00999928
+      vertex -13.6064 7.1914 3.01
+    endloop
+  endfacet
+  facet normal 0.817707 -0.575635 0
+    outer loop
+      vertex -13.6064 7.1914 0.00999928
+      vertex -13.6629 7.11114 3.01
+      vertex -13.6629 7.11114 0.00999928
+    endloop
+  endfacet
+  facet normal 0.49291 0.87008 -0
+    outer loop
+      vertex -12.9428 4.23616 0.00999928
+      vertex -13.0282 4.28454 3.53992
+      vertex -12.9428 4.23616 3.574
+    endloop
+  endfacet
+  facet normal 0.49291 0.87008 0
+    outer loop
+      vertex -13.0282 4.28454 3.53992
+      vertex -12.9428 4.23616 0.00999928
+      vertex -13.0282 4.28454 0.00999928
+    endloop
+  endfacet
+  facet normal -0.073549 -0.997292 0
+    outer loop
+      vertex -11.9019 7.99759 0.00999928
+      vertex -11.804 7.99037 3.01
+      vertex -11.9019 7.99759 3.01
+    endloop
+  endfacet
+  facet normal -0.073549 -0.997292 -0
+    outer loop
+      vertex -11.804 7.99037 3.01
+      vertex -11.9019 7.99759 0.00999928
+      vertex -11.804 7.99037 0.00999928
+    endloop
+  endfacet
+  facet normal -0.0245594 -0.999698 0
+    outer loop
+      vertex -12 8 0.00999928
+      vertex -11.9019 7.99759 3.01
+      vertex -12 8 3.01
+    endloop
+  endfacet
+  facet normal -0.0245594 -0.999698 -0
+    outer loop
+      vertex -11.9019 7.99759 3.01
+      vertex -12 8 0.00999928
+      vertex -11.9019 7.99759 0.00999928
+    endloop
+  endfacet
+  facet normal 0.975411 0.220393 -4.57252e-05
+    outer loop
+      vertex -13.9401 5.51404 0.00999928
+      vertex -13.9616 5.60982 3.0263
+      vertex -13.9503 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 0.976056 0.217517 -0
+    outer loop
+      vertex -13.9401 5.51404 0.00999928
+      vertex -13.9503 5.55981 3.03247
+      vertex -13.9401 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal 0.97572 0.219023 0
+    outer loop
+      vertex -13.9616 5.60982 3.0263
+      vertex -13.9401 5.51404 0.00999928
+      vertex -13.9616 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal -0.535173 0.844742 0
+    outer loop
+      vertex -10.9718 4.28454 0.00999928
+      vertex -10.8889 4.33706 3.5032
+      vertex -10.8889 4.33706 0.00999928
+    endloop
+  endfacet
+  facet normal -0.538415 0.84268 0.000107927
+    outer loop
+      vertex -10.8889 4.33706 3.5032
+      vertex -10.9718 4.28454 0.00999928
+      vertex -10.8948 4.33329 3.50559
+    endloop
+  endfacet
+  facet normal -0.534922 0.844902 0
+    outer loop
+      vertex -10.8948 4.33329 3.50559
+      vertex -10.9718 4.28454 0.00999928
+      vertex -10.9718 4.28454 3.53992
+    endloop
+  endfacet
+  facet normal 0.575647 -0.817698 0
+    outer loop
+      vertex -13.1914 7.60641 0.00999928
+      vertex -13.1111 7.66294 3.01
+      vertex -13.1914 7.60641 3.01
+    endloop
+  endfacet
+  facet normal 0.575647 -0.817698 0
+    outer loop
+      vertex -13.1111 7.66294 3.01
+      vertex -13.1914 7.60641 0.00999928
+      vertex -13.1111 7.66294 0.00999928
+    endloop
+  endfacet
+  facet normal 0.0245594 0.999698 -0
+    outer loop
+      vertex -12 4 0.00999928
+      vertex -12.0981 4.00241 3.76241
+      vertex -12 4 3.76449
+    endloop
+  endfacet
+  facet normal 0.0245594 0.999698 0
+    outer loop
+      vertex -12.0981 4.00241 3.76241
+      vertex -12 4 0.00999928
+      vertex -12.0981 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal 0.535173 -0.844742 0
+    outer loop
+      vertex -13.1111 7.66294 0.00999928
+      vertex -13.0282 7.71546 3.01
+      vertex -13.1111 7.66294 3.01
+    endloop
+  endfacet
+  facet normal 0.535173 -0.844742 0
+    outer loop
+      vertex -13.0282 7.71546 3.01
+      vertex -13.1111 7.66294 0.00999928
+      vertex -13.0282 7.71546 0.00999928
+    endloop
+  endfacet
+  facet normal 0.870382 0.492377 -6.16218e-06
+    outer loop
+      vertex -13.7155 4.97179 0.00999928
+      vertex -13.7638 5.05721 3.15294
+      vertex -13.7254 4.98933 3.17537
+    endloop
+  endfacet
+  facet normal 0.870859 0.491534 -0
+    outer loop
+      vertex -13.7155 4.97179 0.00999928
+      vertex -13.7254 4.98933 3.17537
+      vertex -13.7155 4.97179 3.18213
+    endloop
+  endfacet
+  facet normal 0.870479 0.492205 0
+    outer loop
+      vertex -13.7638 5.05721 3.15294
+      vertex -13.7155 4.97179 0.00999928
+      vertex -13.7638 5.05721 0.00999928
+    endloop
+  endfacet
+  facet normal 0.788325 0.615259 -0
+    outer loop
+      vertex -13.546 4.73121 0.00999928
+      vertex -13.6064 4.8086 3.24758
+      vertex -13.546 4.73121 3.28188
+    endloop
+  endfacet
+  facet normal 0.788325 0.615259 0
+    outer loop
+      vertex -13.6064 4.8086 3.24758
+      vertex -13.546 4.73121 0.00999928
+      vertex -13.6064 4.8086 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 0.40542 0
+    outer loop
+      vertex -10.192 5.14489 0.00999928
+      vertex -10.1522 5.23463 3.09999
+      vertex -10.1522 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 0.40542 0
+    outer loop
+      vertex -10.1522 5.23463 3.09999
+      vertex -10.192 5.14489 0.00999928
+      vertex -10.192 5.14489 3.12482
+    endloop
+  endfacet
+  facet normal -0.933096 0.359628 0
+    outer loop
+      vertex -10.1522 5.23463 0.00999928
+      vertex -10.1169 5.32622 3.07752
+      vertex -10.1169 5.32622 0.00999928
+    endloop
+  endfacet
+  facet normal -0.932867 0.360221 -2.03672e-05
+    outer loop
+      vertex -10.1169 5.32622 3.07752
+      vertex -10.1522 5.23463 0.00999928
+      vertex -10.1382 5.27106 3.08991
+    endloop
+  endfacet
+  facet normal -0.933445 0.358722 0
+    outer loop
+      vertex -10.1382 5.27106 3.08991
+      vertex -10.1522 5.23463 0.00999928
+      vertex -10.1522 5.23463 3.09999
+    endloop
+  endfacet
+  facet normal 0.999701 -0.02445 0
+    outer loop
+      vertex -14 6 3
+      vertex -13.9976 6.09813 0.00999928
+      vertex -13.9976 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal 0.999701 -0.02445 0
+    outer loop
+      vertex -13.9976 6.09813 0.00999928
+      vertex -14 6 3
+      vertex -14 6 0.00999928
+    endloop
+  endfacet
+  facet normal 0.219076 -0.975708 0
+    outer loop
+      vertex -12.486 7.94006 0.00999928
+      vertex -12.3902 7.96157 3.01
+      vertex -12.486 7.94006 3.01
+    endloop
+  endfacet
+  facet normal 0.219076 -0.975708 0
+    outer loop
+      vertex -12.3902 7.96157 3.01
+      vertex -12.486 7.94006 0.00999928
+      vertex -12.3902 7.96157 0.00999928
+    endloop
+  endfacet
+  facet normal 0.985248 -0.171135 0
+    outer loop
+      vertex -13.9784 6.29346 3.01
+      vertex -13.9616 6.39018 0.00999928
+      vertex -13.9616 6.39018 3.01
+    endloop
+  endfacet
+  facet normal 0.985248 -0.171135 0
+    outer loop
+      vertex -13.9616 6.39018 0.00999928
+      vertex -13.9784 6.29346 3.01
+      vertex -13.9784 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal 0.266719 -0.963774 0
+    outer loop
+      vertex -12.5806 7.91388 0.00999928
+      vertex -12.486 7.94006 3.01
+      vertex -12.5806 7.91388 3.01
+    endloop
+  endfacet
+  facet normal 0.266719 -0.963774 0
+    outer loop
+      vertex -12.486 7.94006 3.01
+      vertex -12.5806 7.91388 0.00999928
+      vertex -12.486 7.94006 0.00999928
+    endloop
+  endfacet
+  facet normal 0.788325 -0.615259 0
+    outer loop
+      vertex -13.6064 7.1914 3.01
+      vertex -13.546 7.26879 0.00999928
+      vertex -13.546 7.26879 3.01
+    endloop
+  endfacet
+  facet normal 0.788325 -0.615259 0
+    outer loop
+      vertex -13.546 7.26879 0.00999928
+      vertex -13.6064 7.1914 3.01
+      vertex -13.6064 7.1914 0.00999928
+    endloop
+  endfacet
+  facet normal -0.266719 -0.963774 0
+    outer loop
+      vertex -11.514 7.94006 0.00999928
+      vertex -11.4194 7.91388 3.01
+      vertex -11.514 7.94006 3.01
+    endloop
+  endfacet
+  facet normal -0.266719 -0.963774 -0
+    outer loop
+      vertex -11.4194 7.91388 3.01
+      vertex -11.514 7.94006 0.00999928
+      vertex -11.4194 7.91388 0.00999928
+    endloop
+  endfacet
+  facet normal 0.97572 -0.219023 0
+    outer loop
+      vertex -13.9616 6.39018 3.01
+      vertex -13.9401 6.48596 0.00999928
+      vertex -13.9401 6.48596 3.01
+    endloop
+  endfacet
+  facet normal 0.97572 -0.219023 0
+    outer loop
+      vertex -13.9401 6.48596 0.00999928
+      vertex -13.9616 6.39018 3.01
+      vertex -13.9616 6.39018 0.00999928
+    endloop
+  endfacet
+  facet normal 0.449451 0.893305 -0
+    outer loop
+      vertex -12.8551 4.19202 0.00999928
+      vertex -12.8966 4.2129 3.59038
+      vertex -12.8551 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal 0.449686 0.893187 3.40941e-06
+    outer loop
+      vertex -12.8551 4.19202 0.00999928
+      vertex -12.9428 4.23616 3.574
+      vertex -12.8966 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 0.449575 0.893243 0
+    outer loop
+      vertex -12.9428 4.23616 3.574
+      vertex -12.8551 4.19202 0.00999928
+      vertex -12.9428 4.23616 0.00999928
+    endloop
+  endfacet
+  facet normal 0.844461 0.535616 -0
+    outer loop
+      vertex -13.6629 4.88886 0.00999928
+      vertex -13.7155 4.97179 3.18213
+      vertex -13.6629 4.88886 3.21412
+    endloop
+  endfacet
+  facet normal 0.844461 0.535616 0
+    outer loop
+      vertex -13.7155 4.97179 3.18213
+      vertex -13.6629 4.88886 0.00999928
+      vertex -13.7155 4.97179 0.00999928
+    endloop
+  endfacet
+  facet normal -0.31369 0.949526 0
+    outer loop
+      vertex -11.4194 4.08612 0.00999928
+      vertex -11.3262 4.11691 3.66529
+      vertex -11.3262 4.11691 0.00999928
+    endloop
+  endfacet
+  facet normal -0.313743 0.949508 1.51104e-06
+    outer loop
+      vertex -11.3262 4.11691 3.66529
+      vertex -11.4194 4.08612 0.00999928
+      vertex -11.387 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal -0.313589 0.949559 0
+    outer loop
+      vertex -11.387 4.09682 3.68097
+      vertex -11.4194 4.08612 0.00999928
+      vertex -11.4194 4.08612 3.6902
+    endloop
+  endfacet
+  facet normal -0.31369 -0.949526 0
+    outer loop
+      vertex -11.4194 7.91388 0.00999928
+      vertex -11.3262 7.88309 3.01
+      vertex -11.4194 7.91388 3.01
+    endloop
+  endfacet
+  facet normal -0.31369 -0.949526 -0
+    outer loop
+      vertex -11.3262 7.88309 3.01
+      vertex -11.4194 7.91388 0.00999928
+      vertex -11.3262 7.88309 0.00999928
+    endloop
+  endfacet
+  facet normal 0.844491 -0.53557 0
+    outer loop
+      vertex -13.7155 7.0282 3.01
+      vertex -13.6629 7.11114 0.00999928
+      vertex -13.6629 7.11114 3.01
+    endloop
+  endfacet
+  facet normal 0.844491 -0.53557 0
+    outer loop
+      vertex -13.6629 7.11114 0.00999928
+      vertex -13.7155 7.0282 3.01
+      vertex -13.7155 7.0282 0.00999928
+    endloop
+  endfacet
+  facet normal 0.575579 0.817746 -0
+    outer loop
+      vertex -13.1111 4.33706 0.00999928
+      vertex -13.1914 4.39358 3.46741
+      vertex -13.1111 4.33706 3.5032
+    endloop
+  endfacet
+  facet normal 0.575579 0.817746 0
+    outer loop
+      vertex -13.1914 4.39358 3.46741
+      vertex -13.1111 4.33706 0.00999928
+      vertex -13.1914 4.39358 0.00999928
+    endloop
+  endfacet
+  facet normal 0.219076 0.975708 -0
+    outer loop
+      vertex -12.3902 4.03843 0.00999928
+      vertex -12.486 4.05994 3.71278
+      vertex -12.3902 4.03843 3.73134
+    endloop
+  endfacet
+  facet normal 0.219076 0.975708 0
+    outer loop
+      vertex -12.486 4.05994 3.71278
+      vertex -12.3902 4.03843 0.00999928
+      vertex -12.486 4.05994 0.00999928
+    endloop
+  endfacet
+  facet normal 0.405401 -0.914139 0
+    outer loop
+      vertex -12.8551 7.80798 0.00999928
+      vertex -12.7654 7.84776 3.01
+      vertex -12.8551 7.80798 3.01
+    endloop
+  endfacet
+  facet normal 0.405401 -0.914139 0
+    outer loop
+      vertex -12.7654 7.84776 3.01
+      vertex -12.8551 7.80798 0.00999928
+      vertex -12.7654 7.84776 0.00999928
+    endloop
+  endfacet
+  facet normal 0.313589 0.949559 -0
+    outer loop
+      vertex -12.5806 4.08612 0.00999928
+      vertex -12.613 4.09682 3.68097
+      vertex -12.5806 4.08612 3.6902
+    endloop
+  endfacet
+  facet normal 0.313743 0.949508 1.51104e-06
+    outer loop
+      vertex -12.5806 4.08612 0.00999928
+      vertex -12.6738 4.11691 3.66529
+      vertex -12.613 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal 0.31369 0.949526 0
+    outer loop
+      vertex -12.6738 4.11691 3.66529
+      vertex -12.5806 4.08612 0.00999928
+      vertex -12.6738 4.11691 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 -0.985276 0
+    outer loop
+      vertex -11.7065 7.97835 0.00999928
+      vertex -11.6098 7.96157 3.01
+      vertex -11.7065 7.97835 3.01
+    endloop
+  endfacet
+  facet normal -0.170971 -0.985276 -0
+    outer loop
+      vertex -11.6098 7.96157 3.01
+      vertex -11.7065 7.97835 0.00999928
+      vertex -11.6098 7.96157 0.00999928
+    endloop
+  endfacet
+  facet normal -0.997293 -0.0735256 0
+    outer loop
+      vertex 13.9904 6.19603 0.00999928
+      vertex 13.994 6.1472 3.00361
+      vertex 13.9904 6.19603 3.00722
+    endloop
+  endfacet
+  facet normal -0.997307 -0.0733463 2.94012e-06
+    outer loop
+      vertex 13.9976 6.09813 0.00999928
+      vertex 13.994 6.1472 3.00361
+      vertex 13.9904 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal -0.99732 -0.0731679 0
+    outer loop
+      vertex 13.994 6.1472 3.00361
+      vertex 13.9976 6.09813 0.00999928
+      vertex 13.9976 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal -0.999701 -0.02445 -0
+    outer loop
+      vertex 14 6 3
+      vertex 13.9976 6.09813 0.00999928
+      vertex 14 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 -0.02445 0
+    outer loop
+      vertex 13.9976 6.09813 0.00999928
+      vertex 14 6 3
+      vertex 13.9976 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal -0.9925 -0.122242 0
+    outer loop
+      vertex 13.9904 6.19603 3.00722
+      vertex 13.9784 6.29346 3.01
+      vertex 13.9784 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 -0.122242 -0
+    outer loop
+      vertex 13.9904 6.19603 3.00722
+      vertex 13.9784 6.29346 0.00999928
+      vertex 13.9904 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal -0.992172 -0.121362 -0.0294284
+    outer loop
+      vertex 13.9784 6.29346 3.01
+      vertex 13.9904 6.19603 3.00722
+      vertex 13.9857 6.23378 3.01
+    endloop
+  endfacet
+  facet normal -0.757297 -0.653071 0
+    outer loop
+      vertex 13.546 7.26879 0.00999928
+      vertex 13.4819 7.34312 3.01
+      vertex 13.4819 7.34312 0.00999928
+    endloop
+  endfacet
+  facet normal -0.757297 -0.653071 0
+    outer loop
+      vertex 13.4819 7.34312 3.01
+      vertex 13.546 7.26879 0.00999928
+      vertex 13.546 7.26879 3.01
+    endloop
+  endfacet
+  facet normal -0.0245594 0.999698 0
+    outer loop
+      vertex 12 4 0.00999928
+      vertex 12.0981 4.00241 3.76241
+      vertex 12.0981 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal -0.0245594 0.999698 0
+    outer loop
+      vertex 12.0981 4.00241 3.76241
+      vertex 12 4 0.00999928
+      vertex 12 4 3.76449
+    endloop
+  endfacet
+  facet normal -0.122356 0.992486 0
+    outer loop
+      vertex 12.196 4.00963 0.00999928
+      vertex 12.2935 4.02165 3.74581
+      vertex 12.2935 4.02165 0.00999928
+    endloop
+  endfacet
+  facet normal -0.122356 0.992486 0
+    outer loop
+      vertex 12.2935 4.02165 3.74581
+      vertex 12.196 4.00963 0.00999928
+      vertex 12.196 4.00963 3.75618
+    endloop
+  endfacet
+  facet normal 0.615146 -0.788413 0
+    outer loop
+      vertex 10.7312 7.54602 0.00999928
+      vertex 10.8086 7.60641 3.01
+      vertex 10.7312 7.54602 3.01
+    endloop
+  endfacet
+  facet normal 0.615146 -0.788413 0
+    outer loop
+      vertex 10.8086 7.60641 3.01
+      vertex 10.7312 7.54602 0.00999928
+      vertex 10.8086 7.60641 0.00999928
+    endloop
+  endfacet
+  facet normal -0.653339 -0.757066 0
+    outer loop
+      vertex 13.2688 7.54602 0.00999928
+      vertex 13.3431 7.4819 3.01
+      vertex 13.2688 7.54602 3.01
+    endloop
+  endfacet
+  facet normal -0.653339 -0.757066 -0
+    outer loop
+      vertex 13.3431 7.4819 3.01
+      vertex 13.2688 7.54602 0.00999928
+      vertex 13.3431 7.4819 0.00999928
+    endloop
+  endfacet
+  facet normal 0.359859 0.933007 -0
+    outer loop
+      vertex 11.3262 4.11691 0.00999928
+      vertex 11.2346 4.15224 3.63772
+      vertex 11.3262 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal 0.359859 0.933007 0
+    outer loop
+      vertex 11.2346 4.15224 3.63772
+      vertex 11.3262 4.11691 0.00999928
+      vertex 11.2346 4.15224 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 0.615259 0
+    outer loop
+      vertex 13.546 4.73121 0.00999928
+      vertex 13.6064 4.8086 3.24758
+      vertex 13.6064 4.8086 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 0.615259 0
+    outer loop
+      vertex 13.6064 4.8086 3.24758
+      vertex 13.546 4.73121 0.00999928
+      vertex 13.546 4.73121 3.28188
+    endloop
+  endfacet
+  facet normal -0.788325 -0.615259 0
+    outer loop
+      vertex 13.6064 7.1914 0.00999928
+      vertex 13.546 7.26879 3.01
+      vertex 13.546 7.26879 0.00999928
+    endloop
+  endfacet
+  facet normal -0.788325 -0.615259 0
+    outer loop
+      vertex 13.546 7.26879 3.01
+      vertex 13.6064 7.1914 0.00999928
+      vertex 13.6064 7.1914 3.01
+    endloop
+  endfacet
+  facet normal 0.932867 0.360221 -2.03672e-05
+    outer loop
+      vertex 10.1522 5.23463 0.00999928
+      vertex 10.1169 5.32622 3.07752
+      vertex 10.1382 5.27106 3.08991
+    endloop
+  endfacet
+  facet normal 0.933445 0.358722 -0
+    outer loop
+      vertex 10.1522 5.23463 0.00999928
+      vertex 10.1382 5.27106 3.08991
+      vertex 10.1522 5.23463 3.09999
+    endloop
+  endfacet
+  facet normal 0.933096 0.359628 0
+    outer loop
+      vertex 10.1169 5.32622 3.07752
+      vertex 10.1522 5.23463 0.00999928
+      vertex 10.1169 5.32622 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724162 0.68963 0
+    outer loop
+      vertex 13.4142 4.58579 0.00999928
+      vertex 13.4819 4.65688 3.31846
+      vertex 13.4819 4.65688 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724066 0.68973 -4.12488e-06
+    outer loop
+      vertex 13.4819 4.65688 3.31846
+      vertex 13.4142 4.58579 0.00999928
+      vertex 13.4142 4.58581 3.35424
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 13.4142 4.58581 3.35424
+      vertex 13.4142 4.58579 0.00999928
+      vertex 13.4142 4.58579 3.35425
+    endloop
+  endfacet
+  facet normal -0.97572 0.219023 0
+    outer loop
+      vertex 13.9401 5.51404 0.00999928
+      vertex 13.9616 5.60982 3.0263
+      vertex 13.9616 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal -0.975411 0.220393 -4.57252e-05
+    outer loop
+      vertex 13.9616 5.60982 3.0263
+      vertex 13.9401 5.51404 0.00999928
+      vertex 13.9503 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal -0.976056 0.217517 0
+    outer loop
+      vertex 13.9503 5.55981 3.03247
+      vertex 13.9401 5.51404 0.00999928
+      vertex 13.9401 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal -0.997319 0.0731828 0
+    outer loop
+      vertex 13.9976 5.90186 0.00999928
+      vertex 13.994 5.8528 3.00361
+      vertex 13.9976 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal -0.997306 0.0733538 2.8179e-06
+    outer loop
+      vertex 13.9904 5.80397 0.00999928
+      vertex 13.994 5.8528 3.00361
+      vertex 13.9976 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal -0.997293 0.0735256 0
+    outer loop
+      vertex 13.994 5.8528 3.00361
+      vertex 13.9904 5.80397 0.00999928
+      vertex 13.9904 5.80397 3.00722
+    endloop
+  endfacet
+  facet normal -0.949505 -0.313751 0
+    outer loop
+      vertex 13.9139 6.58057 0.00999928
+      vertex 13.8831 6.67378 3.01
+      vertex 13.8831 6.67378 0.00999928
+    endloop
+  endfacet
+  facet normal -0.949505 -0.313751 0
+    outer loop
+      vertex 13.8831 6.67378 3.01
+      vertex 13.9139 6.58057 0.00999928
+      vertex 13.9139 6.58057 3.01
+    endloop
+  endfacet
+  facet normal -0.073549 0.997292 0
+    outer loop
+      vertex 12.0981 4.00241 0.00999928
+      vertex 12.196 4.00963 3.75618
+      vertex 12.196 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal -0.073549 0.997292 0
+    outer loop
+      vertex 12.196 4.00963 3.75618
+      vertex 12.0981 4.00241 0.00999928
+      vertex 12.0981 4.00241 3.76241
+    endloop
+  endfacet
+  facet normal -0.892956 0.450144 0
+    outer loop
+      vertex 13.7638 5.05721 0.00999928
+      vertex 13.808 5.14489 3.12482
+      vertex 13.808 5.14489 0.00999928
+    endloop
+  endfacet
+  facet normal -0.893739 0.448588 5.49163e-05
+    outer loop
+      vertex 13.808 5.14489 3.12482
+      vertex 13.7638 5.05721 0.00999928
+      vertex 13.8001 5.12915 3.12918
+    endloop
+  endfacet
+  facet normal -0.892783 0.450487 0
+    outer loop
+      vertex 13.8001 5.12915 3.12918
+      vertex 13.7638 5.05721 0.00999928
+      vertex 13.7638 5.05721 3.15294
+    endloop
+  endfacet
+  facet normal -0.31369 0.949526 0
+    outer loop
+      vertex 12.5806 4.08612 0.00999928
+      vertex 12.6738 4.11691 3.66529
+      vertex 12.6738 4.11691 0.00999928
+    endloop
+  endfacet
+  facet normal -0.313743 0.949508 1.51104e-06
+    outer loop
+      vertex 12.6738 4.11691 3.66529
+      vertex 12.5806 4.08612 0.00999928
+      vertex 12.613 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal -0.313589 0.949559 0
+    outer loop
+      vertex 12.613 4.09682 3.68097
+      vertex 12.5806 4.08612 0.00999928
+      vertex 12.5806 4.08612 3.6902
+    endloop
+  endfacet
+  facet normal -0.870455 -0.492249 0
+    outer loop
+      vertex 13.7638 6.94279 0.00999928
+      vertex 13.7155 7.0282 3.01
+      vertex 13.7155 7.0282 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870455 -0.492249 0
+    outer loop
+      vertex 13.7155 7.0282 3.01
+      vertex 13.7638 6.94279 0.00999928
+      vertex 13.7638 6.94279 3.01
+    endloop
+  endfacet
+  facet normal -0.219076 0.975708 0
+    outer loop
+      vertex 12.3902 4.03843 0.00999928
+      vertex 12.486 4.05994 3.71278
+      vertex 12.486 4.05994 0.00999928
+    endloop
+  endfacet
+  facet normal -0.219076 0.975708 0
+    outer loop
+      vertex 12.486 4.05994 3.71278
+      vertex 12.3902 4.03843 0.00999928
+      vertex 12.3902 4.03843 3.73134
+    endloop
+  endfacet
+  facet normal -0.575647 -0.817698 0
+    outer loop
+      vertex 13.1111 7.66294 0.00999928
+      vertex 13.1914 7.60641 3.01
+      vertex 13.1111 7.66294 3.01
+    endloop
+  endfacet
+  facet normal -0.575647 -0.817698 -0
+    outer loop
+      vertex 13.1914 7.60641 3.01
+      vertex 13.1111 7.66294 0.00999928
+      vertex 13.1914 7.60641 0.00999928
+    endloop
+  endfacet
+  facet normal 0.992172 -0.121362 -0.0294284
+    outer loop
+      vertex 10.0096 6.19603 3.00722
+      vertex 10.0216 6.29346 3.01
+      vertex 10.0143 6.23378 3.01
+    endloop
+  endfacet
+  facet normal 0.9925 -0.122242 0
+    outer loop
+      vertex 10.0216 6.29346 3.01
+      vertex 10.0096 6.19603 3.00722
+      vertex 10.0216 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal 0.9925 -0.122242 0
+    outer loop
+      vertex 10.0216 6.29346 0.00999928
+      vertex 10.0096 6.19603 3.00722
+      vertex 10.0096 6.19603 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844461 0.535616 0
+    outer loop
+      vertex 13.6629 4.88886 0.00999928
+      vertex 13.7155 4.97179 3.18213
+      vertex 13.7155 4.97179 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844461 0.535616 0
+    outer loop
+      vertex 13.7155 4.97179 3.18213
+      vertex 13.6629 4.88886 0.00999928
+      vertex 13.6629 4.88886 3.21412
+    endloop
+  endfacet
+  facet normal -0.844491 -0.53557 0
+    outer loop
+      vertex 13.7155 7.0282 0.00999928
+      vertex 13.6629 7.11114 3.01
+      vertex 13.6629 7.11114 0.00999928
+    endloop
+  endfacet
+  facet normal -0.844491 -0.53557 0
+    outer loop
+      vertex 13.6629 7.11114 3.01
+      vertex 13.7155 7.0282 0.00999928
+      vertex 13.7155 7.0282 3.01
+    endloop
+  endfacet
+  facet normal -0.892956 -0.450144 0
+    outer loop
+      vertex 13.808 6.85511 0.00999928
+      vertex 13.7638 6.94279 3.01
+      vertex 13.7638 6.94279 0.00999928
+    endloop
+  endfacet
+  facet normal -0.892956 -0.450144 0
+    outer loop
+      vertex 13.7638 6.94279 3.01
+      vertex 13.808 6.85511 0.00999928
+      vertex 13.808 6.85511 3.01
+    endloop
+  endfacet
+  facet normal 0.844491 -0.53557 0
+    outer loop
+      vertex 10.2845 7.0282 3.01
+      vertex 10.3371 7.11114 0.00999928
+      vertex 10.3371 7.11114 3.01
+    endloop
+  endfacet
+  facet normal 0.844491 -0.53557 0
+    outer loop
+      vertex 10.3371 7.11114 0.00999928
+      vertex 10.2845 7.0282 3.01
+      vertex 10.2845 7.0282 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449575 0.893243 0
+    outer loop
+      vertex 12.8551 4.19202 0.00999928
+      vertex 12.9428 4.23616 3.574
+      vertex 12.9428 4.23616 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449686 0.893187 3.40941e-06
+    outer loop
+      vertex 12.9428 4.23616 3.574
+      vertex 12.8551 4.19202 0.00999928
+      vertex 12.8966 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal -0.449451 0.893305 0
+    outer loop
+      vertex 12.8966 4.2129 3.59038
+      vertex 12.8551 4.19202 0.00999928
+      vertex 12.8551 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal -0.535173 0.844742 0
+    outer loop
+      vertex 13.0282 4.28454 0.00999928
+      vertex 13.1111 4.33706 3.5032
+      vertex 13.1111 4.33706 0.00999928
+    endloop
+  endfacet
+  facet normal -0.538415 0.84268 0.000107927
+    outer loop
+      vertex 13.1111 4.33706 3.5032
+      vertex 13.0282 4.28454 0.00999928
+      vertex 13.1052 4.33329 3.50559
+    endloop
+  endfacet
+  facet normal -0.534922 0.844902 0
+    outer loop
+      vertex 13.1052 4.33329 3.50559
+      vertex 13.0282 4.28454 0.00999928
+      vertex 13.0282 4.28454 3.53992
+    endloop
+  endfacet
+  facet normal 0.999701 0.0244476 -0
+    outer loop
+      vertex 10.0024 5.90186 0.00999928
+      vertex 10 6 3
+      vertex 10.0024 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal 0.999701 0.0244476 0
+    outer loop
+      vertex 10 6 3
+      vertex 10.0024 5.90186 0.00999928
+      vertex 10 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 0.266882 0
+    outer loop
+      vertex 13.9139 5.41943 0.00999928
+      vertex 13.9401 5.51404 3.04041
+      vertex 13.9401 5.51404 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 0.266882 0
+    outer loop
+      vertex 13.9401 5.51404 3.04041
+      vertex 13.9139 5.41943 0.00999928
+      vertex 13.9139 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0.122356 0.992486 -0
+    outer loop
+      vertex 11.804 4.00963 0.00999928
+      vertex 11.7065 4.02165 3.74581
+      vertex 11.804 4.00963 3.75618
+    endloop
+  endfacet
+  facet normal 0.122356 0.992486 0
+    outer loop
+      vertex 11.7065 4.02165 3.74581
+      vertex 11.804 4.00963 0.00999928
+      vertex 11.7065 4.02165 0.00999928
+    endloop
+  endfacet
+  facet normal 0.219076 -0.975708 0
+    outer loop
+      vertex 11.514 7.94006 0.00999928
+      vertex 11.6098 7.96157 3.01
+      vertex 11.514 7.94006 3.01
+    endloop
+  endfacet
+  facet normal 0.219076 -0.975708 0
+    outer loop
+      vertex 11.6098 7.96157 3.01
+      vertex 11.514 7.94006 0.00999928
+      vertex 11.6098 7.96157 0.00999928
+    endloop
+  endfacet
+  facet normal 0.170971 0.985276 -0
+    outer loop
+      vertex 11.7065 4.02165 0.00999928
+      vertex 11.6098 4.03843 3.73134
+      vertex 11.7065 4.02165 3.74581
+    endloop
+  endfacet
+  facet normal 0.170971 0.985276 0
+    outer loop
+      vertex 11.6098 4.03843 3.73134
+      vertex 11.7065 4.02165 0.00999928
+      vertex 11.6098 4.03843 0.00999928
+    endloop
+  endfacet
+  facet normal 0.985248 -0.171135 0
+    outer loop
+      vertex 10.0216 6.29346 3.01
+      vertex 10.0384 6.39018 0.00999928
+      vertex 10.0384 6.39018 3.01
+    endloop
+  endfacet
+  facet normal 0.985248 -0.171135 0
+    outer loop
+      vertex 10.0384 6.39018 0.00999928
+      vertex 10.0216 6.29346 3.01
+      vertex 10.0216 6.29346 0.00999928
+    endloop
+  endfacet
+  facet normal 0.9925 0.122242 -0
+    outer loop
+      vertex 10.0216 5.70654 0.00999928
+      vertex 10.0096 5.80397 3.00722
+      vertex 10.0216 5.70654 3.0144
+    endloop
+  endfacet
+  facet normal 0.9925 0.122242 0
+    outer loop
+      vertex 10.0096 5.80397 3.00722
+      vertex 10.0216 5.70654 0.00999928
+      vertex 10.0096 5.80397 0.00999928
+    endloop
+  endfacet
+  facet normal 0.724066 0.68973 -4.12488e-06
+    outer loop
+      vertex 10.5858 4.58579 0.00999928
+      vertex 10.5181 4.65688 3.31846
+      vertex 10.5858 4.58581 3.35424
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10.5858 4.58579 0.00999928
+      vertex 10.5858 4.58581 3.35424
+      vertex 10.5858 4.58579 3.35425
+    endloop
+  endfacet
+  facet normal 0.724162 0.68963 0
+    outer loop
+      vertex 10.5181 4.65688 3.31846
+      vertex 10.5858 4.58579 0.00999928
+      vertex 10.5181 4.65688 0.00999928
+    endloop
+  endfacet
+  facet normal 0.914131 0.40542 -0
+    outer loop
+      vertex 10.192 5.14489 0.00999928
+      vertex 10.1522 5.23463 3.09999
+      vertex 10.192 5.14489 3.12482
+    endloop
+  endfacet
+  facet normal 0.914131 0.40542 0
+    outer loop
+      vertex 10.1522 5.23463 3.09999
+      vertex 10.192 5.14489 0.00999928
+      vertex 10.1522 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 0.122242 0
+    outer loop
+      vertex 13.9784 5.70654 0.00999928
+      vertex 13.9904 5.80397 3.00722
+      vertex 13.9904 5.80397 0.00999928
+    endloop
+  endfacet
+  facet normal -0.9925 0.122242 0
+    outer loop
+      vertex 13.9904 5.80397 3.00722
+      vertex 13.9784 5.70654 0.00999928
+      vertex 13.9784 5.70654 3.0144
+    endloop
+  endfacet
+  facet normal 0.219076 0.975708 -0
+    outer loop
+      vertex 11.6098 4.03843 0.00999928
+      vertex 11.514 4.05994 3.71278
+      vertex 11.6098 4.03843 3.73134
+    endloop
+  endfacet
+  facet normal 0.219076 0.975708 0
+    outer loop
+      vertex 11.514 4.05994 3.71278
+      vertex 11.6098 4.03843 0.00999928
+      vertex 11.514 4.05994 0.00999928
+    endloop
+  endfacet
+  facet normal -0.933096 -0.359628 0
+    outer loop
+      vertex 13.8831 6.67378 0.00999928
+      vertex 13.8478 6.76537 3.01
+      vertex 13.8478 6.76537 0.00999928
+    endloop
+  endfacet
+  facet normal -0.933096 -0.359628 0
+    outer loop
+      vertex 13.8478 6.76537 3.01
+      vertex 13.8831 6.67378 0.00999928
+      vertex 13.8831 6.67378 3.01
+    endloop
+  endfacet
+  facet normal 0.313589 0.949559 -0
+    outer loop
+      vertex 11.4194 4.08612 0.00999928
+      vertex 11.387 4.09682 3.68097
+      vertex 11.4194 4.08612 3.6902
+    endloop
+  endfacet
+  facet normal 0.313743 0.949508 1.51104e-06
+    outer loop
+      vertex 11.4194 4.08612 0.00999928
+      vertex 11.3262 4.11691 3.66529
+      vertex 11.387 4.09682 3.68097
+    endloop
+  endfacet
+  facet normal 0.31369 0.949526 0
+    outer loop
+      vertex 11.3262 4.11691 3.66529
+      vertex 11.4194 4.08612 0.00999928
+      vertex 11.3262 4.11691 0.00999928
+    endloop
+  endfacet
+  facet normal 0.689525 0.724261 -0
+    outer loop
+      vertex 10.6569 4.5181 0.00999928
+      vertex 10.5858 4.58579 3.35425
+      vertex 10.6569 4.5181 3.39259
+    endloop
+  endfacet
+  facet normal 0.689525 0.724261 0
+    outer loop
+      vertex 10.5858 4.58579 3.35425
+      vertex 10.6569 4.5181 0.00999928
+      vertex 10.5858 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal -0.266719 -0.963774 0
+    outer loop
+      vertex 12.486 7.94006 0.00999928
+      vertex 12.5806 7.91388 3.01
+      vertex 12.486 7.94006 3.01
+    endloop
+  endfacet
+  facet normal -0.266719 -0.963774 -0
+    outer loop
+      vertex 12.5806 7.91388 3.01
+      vertex 12.486 7.94006 0.00999928
+      vertex 12.5806 7.91388 0.00999928
+    endloop
+  endfacet
+  facet normal 0.817534 0.575881 -9.2087e-06
+    outer loop
+      vertex 10.3936 4.8086 0.00999928
+      vertex 10.3371 4.88886 3.21412
+      vertex 10.3631 4.85195 3.22836
+    endloop
+  endfacet
+  facet normal 0.817856 0.575423 -0
+    outer loop
+      vertex 10.3936 4.8086 0.00999928
+      vertex 10.3631 4.85195 3.22836
+      vertex 10.3936 4.8086 3.24758
+    endloop
+  endfacet
+  facet normal 0.817707 0.575635 0
+    outer loop
+      vertex 10.3371 4.88886 3.21412
+      vertex 10.3936 4.8086 0.00999928
+      vertex 10.3371 4.88886 0.00999928
+    endloop
+  endfacet
+  facet normal -0.757297 0.653071 0
+    outer loop
+      vertex 13.4819 4.65688 0.00999928
+      vertex 13.546 4.73121 3.28188
+      vertex 13.546 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal -0.756488 0.654008 -3.71393e-05
+    outer loop
+      vertex 13.546 4.73121 3.28188
+      vertex 13.4819 4.65688 0.00999928
+      vertex 13.534 4.71733 3.28803
+    endloop
+  endfacet
+  facet normal -0.757485 0.652853 0
+    outer loop
+      vertex 13.534 4.71733 3.28803
+      vertex 13.4819 4.65688 0.00999928
+      vertex 13.4819 4.65688 3.31846
+    endloop
+  endfacet
+  facet normal -0.0245594 -0.999698 0
+    outer loop
+      vertex 12 8 0.00999928
+      vertex 12.0981 7.99759 3.01
+      vertex 12 8 3.01
+    endloop
+  endfacet
+  facet normal -0.0245594 -0.999698 -0
+    outer loop
+      vertex 12.0981 7.99759 3.01
+      vertex 12 8 0.00999928
+      vertex 12.0981 7.99759 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870479 0.492205 0
+    outer loop
+      vertex 13.7155 4.97179 0.00999928
+      vertex 13.7638 5.05721 3.15294
+      vertex 13.7638 5.05721 0.00999928
+    endloop
+  endfacet
+  facet normal -0.870382 0.492377 -6.16218e-06
+    outer loop
+      vertex 13.7638 5.05721 3.15294
+      vertex 13.7155 4.97179 0.00999928
+      vertex 13.7254 4.98933 3.17537
+    endloop
+  endfacet
+  facet normal -0.870859 0.491534 0
+    outer loop
+      vertex 13.7254 4.98933 3.17537
+      vertex 13.7155 4.97179 0.00999928
+      vertex 13.7155 4.97179 3.18213
+    endloop
+  endfacet
+  facet normal 0.689525 -0.724261 0
+    outer loop
+      vertex 10.5858 7.41421 0.00999928
+      vertex 10.6569 7.4819 3.01
+      vertex 10.5858 7.41421 3.01
+    endloop
+  endfacet
+  facet normal 0.689525 -0.724261 0
+    outer loop
+      vertex 10.6569 7.4819 3.01
+      vertex 10.5858 7.41421 0.00999928
+      vertex 10.6569 7.4819 0.00999928
+    endloop
+  endfacet
+  facet normal -0.449575 -0.893243 0
+    outer loop
+      vertex 12.8551 7.80798 0.00999928
+      vertex 12.9428 7.76384 3.01
+      vertex 12.8551 7.80798 3.01
+    endloop
+  endfacet
+  facet normal -0.449575 -0.893243 -0
+    outer loop
+      vertex 12.9428 7.76384 3.01
+      vertex 12.8551 7.80798 0.00999928
+      vertex 12.9428 7.76384 0.00999928
+    endloop
+  endfacet
+  facet normal -0.073549 -0.997292 0
+    outer loop
+      vertex 12.0981 7.99759 0.00999928
+      vertex 12.196 7.99037 3.01
+      vertex 12.0981 7.99759 3.01
+    endloop
+  endfacet
+  facet normal -0.073549 -0.997292 -0
+    outer loop
+      vertex 12.196 7.99037 3.01
+      vertex 12.0981 7.99759 0.00999928
+      vertex 12.196 7.99037 0.00999928
+    endloop
+  endfacet
+  facet normal -0.122356 -0.992486 0
+    outer loop
+      vertex 12.196 7.99037 0.00999928
+      vertex 12.2935 7.97835 3.01
+      vertex 12.196 7.99037 3.01
+    endloop
+  endfacet
+  facet normal -0.122356 -0.992486 -0
+    outer loop
+      vertex 12.2935 7.97835 3.01
+      vertex 12.196 7.99037 0.00999928
+      vertex 12.2935 7.97835 0.00999928
+    endloop
+  endfacet
+  facet normal -0.575579 0.817746 0
+    outer loop
+      vertex 13.1111 4.33706 0.00999928
+      vertex 13.1914 4.39358 3.46741
+      vertex 13.1914 4.39358 0.00999928
+    endloop
+  endfacet
+  facet normal -0.575579 0.817746 0
+    outer loop
+      vertex 13.1914 4.39358 3.46741
+      vertex 13.1111 4.33706 0.00999928
+      vertex 13.1111 4.33706 3.5032
+    endloop
+  endfacet
+  facet normal -0.266719 0.963774 0
+    outer loop
+      vertex 12.486 4.05994 0.00999928
+      vertex 12.5806 4.08612 3.6902
+      vertex 12.5806 4.08612 0.00999928
+    endloop
+  endfacet
+  facet normal -0.266719 0.963774 0
+    outer loop
+      vertex 12.5806 4.08612 3.6902
+      vertex 12.486 4.05994 0.00999928
+      vertex 12.486 4.05994 3.71278
+    endloop
+  endfacet
+  facet normal -0.949505 0.313751 0
+    outer loop
+      vertex 13.8831 5.32622 0.00999928
+      vertex 13.9139 5.41943 3.05683
+      vertex 13.9139 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal -0.946665 0.322219 -0.000287769
+    outer loop
+      vertex 13.9139 5.41943 3.05683
+      vertex 13.8831 5.32622 0.00999928
+      vertex 13.9123 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal -0.949655 0.313297 0
+    outer loop
+      vertex 13.9123 5.41473 3.05764
+      vertex 13.8831 5.32622 0.00999928
+      vertex 13.8831 5.32622 3.07752
+    endloop
+  endfacet
+  facet normal -0.31369 -0.949526 0
+    outer loop
+      vertex 12.5806 7.91388 0.00999928
+      vertex 12.6738 7.88309 3.01
+      vertex 12.5806 7.91388 3.01
+    endloop
+  endfacet
+  facet normal -0.31369 -0.949526 -0
+    outer loop
+      vertex 12.6738 7.88309 3.01
+      vertex 12.5806 7.91388 0.00999928
+      vertex 12.6738 7.88309 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 -0.933007 0
+    outer loop
+      vertex 12.6738 7.88309 0.00999928
+      vertex 12.7654 7.84776 3.01
+      vertex 12.6738 7.88309 3.01
+    endloop
+  endfacet
+  facet normal -0.359859 -0.933007 -0
+    outer loop
+      vertex 12.7654 7.84776 3.01
+      vertex 12.6738 7.88309 0.00999928
+      vertex 12.7654 7.84776 0.00999928
+    endloop
+  endfacet
+  facet normal 0.653339 -0.757066 0
+    outer loop
+      vertex 10.6569 7.4819 0.00999928
+      vertex 10.7312 7.54602 3.01
+      vertex 10.6569 7.4819 3.01
+    endloop
+  endfacet
+  facet normal 0.653339 -0.757066 0
+    outer loop
+      vertex 10.7312 7.54602 3.01
+      vertex 10.6569 7.4819 0.00999928
+      vertex 10.7312 7.54602 0.00999928
+    endloop
+  endfacet
+  facet normal -0.689525 0.724261 0
+    outer loop
+      vertex 13.3431 4.5181 0.00999928
+      vertex 13.4142 4.58579 3.35425
+      vertex 13.4142 4.58579 0.00999928
+    endloop
+  endfacet
+  facet normal -0.689525 0.724261 0
+    outer loop
+      vertex 13.4142 4.58579 3.35425
+      vertex 13.3431 4.5181 0.00999928
+      vertex 13.3431 4.5181 3.39259
+    endloop
+  endfacet
+  facet normal 0.359859 -0.933007 0
+    outer loop
+      vertex 11.2346 7.84776 0.00999928
+      vertex 11.3262 7.88309 3.01
+      vertex 11.2346 7.84776 3.01
+    endloop
+  endfacet
+  facet normal 0.359859 -0.933007 0
+    outer loop
+      vertex 11.3262 7.88309 3.01
+      vertex 11.2346 7.84776 0.00999928
+      vertex 11.3262 7.88309 0.00999928
+    endloop
+  endfacet
+  facet normal -0.49291 -0.87008 0
+    outer loop
+      vertex 12.9428 7.76384 0.00999928
+      vertex 13.0282 7.71546 3.01
+      vertex 12.9428 7.76384 3.01
+    endloop
+  endfacet
+  facet normal -0.49291 -0.87008 -0
+    outer loop
+      vertex 13.0282 7.71546 3.01
+      vertex 12.9428 7.76384 0.00999928
+      vertex 13.0282 7.71546 0.00999928
+    endloop
+  endfacet
+  facet normal 0.49291 -0.87008 0
+    outer loop
+      vertex 10.9718 7.71546 0.00999928
+      vertex 11.0572 7.76384 3.01
+      vertex 10.9718 7.71546 3.01
+    endloop
+  endfacet
+  facet normal 0.49291 -0.87008 0
+    outer loop
+      vertex 11.0572 7.76384 3.01
+      vertex 10.9718 7.71546 0.00999928
+      vertex 11.0572 7.76384 0.00999928
+    endloop
+  endfacet
+  facet normal 0.0245594 -0.999698 0
+    outer loop
+      vertex 11.9019 7.99759 0.00999928
+      vertex 12 8 3.01
+      vertex 11.9019 7.99759 3.01
+    endloop
+  endfacet
+  facet normal 0.0245594 -0.999698 0
+    outer loop
+      vertex 12 8 3.01
+      vertex 11.9019 7.99759 0.00999928
+      vertex 12 8 0.00999928
+    endloop
+  endfacet
+  facet normal 0.963729 -0.266882 0
+    outer loop
+      vertex 10.0599 6.48596 3.01
+      vertex 10.0861 6.58057 0.00999928
+      vertex 10.0861 6.58057 3.01
+    endloop
+  endfacet
+  facet normal 0.963729 -0.266882 0
+    outer loop
+      vertex 10.0861 6.58057 0.00999928
+      vertex 10.0599 6.48596 3.01
+      vertex 10.0599 6.48596 0.00999928
+    endloop
+  endfacet
+  facet normal 0.788325 0.615259 -0
+    outer loop
+      vertex 10.454 4.73121 0.00999928
+      vertex 10.3936 4.8086 3.24758
+      vertex 10.454 4.73121 3.28188
+    endloop
+  endfacet
+  facet normal 0.788325 0.615259 0
+    outer loop
+      vertex 10.3936 4.8086 3.24758
+      vertex 10.454 4.73121 0.00999928
+      vertex 10.3936 4.8086 0.00999928
+    endloop
+  endfacet
+  facet normal -0.689525 -0.724261 0
+    outer loop
+      vertex 13.3431 7.4819 0.00999928
+      vertex 13.4142 7.41421 3.01
+      vertex 13.3431 7.4819 3.01
+    endloop
+  endfacet
+  facet normal -0.689525 -0.724261 -0
+    outer loop
+      vertex 13.4142 7.41421 3.01
+      vertex 13.3431 7.4819 0.00999928
+      vertex 13.4142 7.41421 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 0.985276 0
+    outer loop
+      vertex 12.2935 4.02165 0.00999928
+      vertex 12.3902 4.03843 3.73134
+      vertex 12.3902 4.03843 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 0.985276 0
+    outer loop
+      vertex 12.3902 4.03843 3.73134
+      vertex 12.2935 4.02165 0.00999928
+      vertex 12.2935 4.02165 3.74581
+    endloop
+  endfacet
+  facet normal -0.817707 -0.575635 0
+    outer loop
+      vertex 13.6629 7.11114 0.00999928
+      vertex 13.6064 7.1914 3.01
+      vertex 13.6064 7.1914 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817707 -0.575635 0
+    outer loop
+      vertex 13.6064 7.1914 3.01
+      vertex 13.6629 7.11114 0.00999928
+      vertex 13.6629 7.11114 3.01
+    endloop
+  endfacet
+  facet normal 0.985937 0.167119 0.000133127
+    outer loop
+      vertex 10.0384 5.60982 0.00999928
+      vertex 10.0216 5.70654 3.0144
+      vertex 10.0217 5.70595 3.01445
+    endloop
+  endfacet
+  facet normal 0.985243 0.17116 -0
+    outer loop
+      vertex 10.0384 5.60982 0.00999928
+      vertex 10.0217 5.70595 3.01445
+      vertex 10.0384 5.60982 3.0263
+    endloop
+  endfacet
+  facet normal 0.985248 0.171135 0
+    outer loop
+      vertex 10.0216 5.70654 3.0144
+      vertex 10.0384 5.60982 0.00999928
+      vertex 10.0216 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal -0.405401 -0.914139 0
+    outer loop
+      vertex 12.7654 7.84776 0.00999928
+      vertex 12.8551 7.80798 3.01
+      vertex 12.7654 7.84776 3.01
+    endloop
+  endfacet
+  facet normal -0.405401 -0.914139 -0
+    outer loop
+      vertex 12.8551 7.80798 3.01
+      vertex 12.7654 7.84776 0.00999928
+      vertex 12.8551 7.80798 0.00999928
+    endloop
+  endfacet
+  facet normal 0.788325 -0.615259 0
+    outer loop
+      vertex 10.3936 7.1914 3.01
+      vertex 10.454 7.26879 0.00999928
+      vertex 10.454 7.26879 3.01
+    endloop
+  endfacet
+  facet normal 0.788325 -0.615259 0
+    outer loop
+      vertex 10.454 7.26879 0.00999928
+      vertex 10.3936 7.1914 3.01
+      vertex 10.3936 7.1914 0.00999928
+    endloop
+  endfacet
+  facet normal 0.575647 -0.817698 0
+    outer loop
+      vertex 10.8086 7.60641 0.00999928
+      vertex 10.8889 7.66294 3.01
+      vertex 10.8086 7.60641 3.01
+    endloop
+  endfacet
+  facet normal 0.575647 -0.817698 0
+    outer loop
+      vertex 10.8889 7.66294 3.01
+      vertex 10.8086 7.60641 0.00999928
+      vertex 10.8889 7.66294 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 0.933007 0
+    outer loop
+      vertex 12.6738 4.11691 0.00999928
+      vertex 12.7654 4.15224 3.63772
+      vertex 12.7654 4.15224 0.00999928
+    endloop
+  endfacet
+  facet normal -0.359859 0.933007 0
+    outer loop
+      vertex 12.7654 4.15224 3.63772
+      vertex 12.6738 4.11691 0.00999928
+      vertex 12.6738 4.11691 3.66529
+    endloop
+  endfacet
+  facet normal 0.170971 -0.985276 0
+    outer loop
+      vertex 11.6098 7.96157 0.00999928
+      vertex 11.7065 7.97835 3.01
+      vertex 11.6098 7.96157 3.01
+    endloop
+  endfacet
+  facet normal 0.170971 -0.985276 0
+    outer loop
+      vertex 11.7065 7.97835 3.01
+      vertex 11.6098 7.96157 0.00999928
+      vertex 11.7065 7.97835 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 -0.171135 0
+    outer loop
+      vertex 13.9784 6.29346 0.00999928
+      vertex 13.9616 6.39018 3.01
+      vertex 13.9616 6.39018 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 -0.171135 0
+    outer loop
+      vertex 13.9616 6.39018 3.01
+      vertex 13.9784 6.29346 0.00999928
+      vertex 13.9784 6.29346 3.01
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244476 0
+    outer loop
+      vertex 13.9976 5.90186 0.00999928
+      vertex 14 6 3
+      vertex 14 6 0.00999928
+    endloop
+  endfacet
+  facet normal -0.999701 0.0244476 0
+    outer loop
+      vertex 14 6 3
+      vertex 13.9976 5.90186 0.00999928
+      vertex 13.9976 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal 0.073549 -0.997292 0
+    outer loop
+      vertex 11.804 7.99037 0.00999928
+      vertex 11.9019 7.99759 3.01
+      vertex 11.804 7.99037 3.01
+    endloop
+  endfacet
+  facet normal 0.073549 -0.997292 0
+    outer loop
+      vertex 11.9019 7.99759 3.01
+      vertex 11.804 7.99037 0.00999928
+      vertex 11.9019 7.99759 0.00999928
+    endloop
+  endfacet
+  facet normal 0.405401 -0.914139 0
+    outer loop
+      vertex 11.1449 7.80798 0.00999928
+      vertex 11.2346 7.84776 3.01
+      vertex 11.1449 7.80798 3.01
+    endloop
+  endfacet
+  facet normal 0.405401 -0.914139 0
+    outer loop
+      vertex 11.2346 7.84776 3.01
+      vertex 11.1449 7.80798 0.00999928
+      vertex 11.2346 7.84776 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 -0.40542 0
+    outer loop
+      vertex 13.8478 6.76537 0.00999928
+      vertex 13.808 6.85511 3.01
+      vertex 13.808 6.85511 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 -0.40542 0
+    outer loop
+      vertex 13.808 6.85511 3.01
+      vertex 13.8478 6.76537 0.00999928
+      vertex 13.8478 6.76537 3.01
+    endloop
+  endfacet
+  facet normal -0.97572 -0.219023 0
+    outer loop
+      vertex 13.9616 6.39018 0.00999928
+      vertex 13.9401 6.48596 3.01
+      vertex 13.9401 6.48596 0.00999928
+    endloop
+  endfacet
+  facet normal -0.97572 -0.219023 0
+    outer loop
+      vertex 13.9401 6.48596 3.01
+      vertex 13.9616 6.39018 0.00999928
+      vertex 13.9616 6.39018 3.01
+    endloop
+  endfacet
+  facet normal -0.724162 -0.68963 0
+    outer loop
+      vertex 13.4819 7.34312 0.00999928
+      vertex 13.4142 7.41421 3.01
+      vertex 13.4142 7.41421 0.00999928
+    endloop
+  endfacet
+  facet normal -0.724162 -0.68963 0
+    outer loop
+      vertex 13.4142 7.41421 3.01
+      vertex 13.4819 7.34312 0.00999928
+      vertex 13.4819 7.34312 3.01
+    endloop
+  endfacet
+  facet normal -0.963729 -0.266882 0
+    outer loop
+      vertex 13.9401 6.48596 0.00999928
+      vertex 13.9139 6.58057 3.01
+      vertex 13.9139 6.58057 0.00999928
+    endloop
+  endfacet
+  facet normal -0.963729 -0.266882 0
+    outer loop
+      vertex 13.9139 6.58057 3.01
+      vertex 13.9401 6.48596 0.00999928
+      vertex 13.9401 6.48596 3.01
+    endloop
+  endfacet
+  facet normal -0.535173 -0.844742 0
+    outer loop
+      vertex 13.0282 7.71546 0.00999928
+      vertex 13.1111 7.66294 3.01
+      vertex 13.0282 7.71546 3.01
+    endloop
+  endfacet
+  facet normal -0.535173 -0.844742 -0
+    outer loop
+      vertex 13.1111 7.66294 3.01
+      vertex 13.0282 7.71546 0.00999928
+      vertex 13.1111 7.66294 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817707 0.575635 0
+    outer loop
+      vertex 13.6064 4.8086 0.00999928
+      vertex 13.6629 4.88886 3.21412
+      vertex 13.6629 4.88886 0.00999928
+    endloop
+  endfacet
+  facet normal -0.817534 0.575881 -9.2087e-06
+    outer loop
+      vertex 13.6629 4.88886 3.21412
+      vertex 13.6064 4.8086 0.00999928
+      vertex 13.6369 4.85195 3.22836
+    endloop
+  endfacet
+  facet normal -0.817856 0.575423 0
+    outer loop
+      vertex 13.6369 4.85195 3.22836
+      vertex 13.6064 4.8086 0.00999928
+      vertex 13.6064 4.8086 3.24758
+    endloop
+  endfacet
+  facet normal 0.534922 0.844902 -0
+    outer loop
+      vertex 10.9718 4.28454 0.00999928
+      vertex 10.8948 4.33329 3.50559
+      vertex 10.9718 4.28454 3.53992
+    endloop
+  endfacet
+  facet normal 0.538415 0.84268 0.000107927
+    outer loop
+      vertex 10.9718 4.28454 0.00999928
+      vertex 10.8889 4.33706 3.5032
+      vertex 10.8948 4.33329 3.50559
+    endloop
+  endfacet
+  facet normal 0.535173 0.844742 0
+    outer loop
+      vertex 10.8889 4.33706 3.5032
+      vertex 10.9718 4.28454 0.00999928
+      vertex 10.8889 4.33706 0.00999928
+    endloop
+  endfacet
+  facet normal -0.405401 0.914139 0
+    outer loop
+      vertex 12.7654 4.15224 0.00999928
+      vertex 12.8551 4.19202 3.60667
+      vertex 12.8551 4.19202 0.00999928
+    endloop
+  endfacet
+  facet normal -0.405401 0.914139 0
+    outer loop
+      vertex 12.8551 4.19202 3.60667
+      vertex 12.7654 4.15224 0.00999928
+      vertex 12.7654 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0.122356 -0.992486 0
+    outer loop
+      vertex 11.7065 7.97835 0.00999928
+      vertex 11.804 7.99037 3.01
+      vertex 11.7065 7.97835 3.01
+    endloop
+  endfacet
+  facet normal 0.122356 -0.992486 0
+    outer loop
+      vertex 11.804 7.99037 3.01
+      vertex 11.7065 7.97835 0.00999928
+      vertex 11.804 7.99037 0.00999928
+    endloop
+  endfacet
+  facet normal 0.963729 0.266882 -0
+    outer loop
+      vertex 10.0861 5.41943 0.00999928
+      vertex 10.0599 5.51404 3.04041
+      vertex 10.0861 5.41943 3.05683
+    endloop
+  endfacet
+  facet normal 0.963729 0.266882 0
+    outer loop
+      vertex 10.0599 5.51404 3.04041
+      vertex 10.0861 5.41943 0.00999928
+      vertex 10.0599 5.51404 0.00999928
+    endloop
+  endfacet
+  facet normal -0.615146 -0.788413 0
+    outer loop
+      vertex 13.1914 7.60641 0.00999928
+      vertex 13.2688 7.54602 3.01
+      vertex 13.1914 7.60641 3.01
+    endloop
+  endfacet
+  facet normal -0.615146 -0.788413 -0
+    outer loop
+      vertex 13.2688 7.54602 3.01
+      vertex 13.1914 7.60641 0.00999928
+      vertex 13.2688 7.54602 0.00999928
+    endloop
+  endfacet
+  facet normal 0.449451 0.893305 -0
+    outer loop
+      vertex 11.1449 4.19202 0.00999928
+      vertex 11.1034 4.2129 3.59038
+      vertex 11.1449 4.19202 3.60667
+    endloop
+  endfacet
+  facet normal 0.449686 0.893187 3.40941e-06
+    outer loop
+      vertex 11.1449 4.19202 0.00999928
+      vertex 11.0572 4.23616 3.574
+      vertex 11.1034 4.2129 3.59038
+    endloop
+  endfacet
+  facet normal 0.449575 0.893243 0
+    outer loop
+      vertex 11.0572 4.23616 3.574
+      vertex 11.1449 4.19202 0.00999928
+      vertex 11.0572 4.23616 0.00999928
+    endloop
+  endfacet
+  facet normal 0.266719 0.963774 -0
+    outer loop
+      vertex 11.514 4.05994 0.00999928
+      vertex 11.4194 4.08612 3.6902
+      vertex 11.514 4.05994 3.71278
+    endloop
+  endfacet
+  facet normal 0.266719 0.963774 0
+    outer loop
+      vertex 11.4194 4.08612 3.6902
+      vertex 11.514 4.05994 0.00999928
+      vertex 11.4194 4.08612 0.00999928
+    endloop
+  endfacet
+  facet normal 0.724162 -0.68963 0
+    outer loop
+      vertex 10.5181 7.34312 3.01
+      vertex 10.5858 7.41421 0.00999928
+      vertex 10.5858 7.41421 3.01
+    endloop
+  endfacet
+  facet normal 0.724162 -0.68963 0
+    outer loop
+      vertex 10.5858 7.41421 0.00999928
+      vertex 10.5181 7.34312 3.01
+      vertex 10.5181 7.34312 0.00999928
+    endloop
+  endfacet
+  facet normal 0.997319 0.0731828 0
+    outer loop
+      vertex 10.006 5.8528 3.00361
+      vertex 10.0024 5.90186 0.00999928
+      vertex 10.0024 5.90186 3.00241
+    endloop
+  endfacet
+  facet normal 0.997293 0.0735256 -0
+    outer loop
+      vertex 10.0096 5.80397 0.00999928
+      vertex 10.006 5.8528 3.00361
+      vertex 10.0096 5.80397 3.00722
+    endloop
+  endfacet
+  facet normal 0.997306 0.0733538 2.8179e-06
+    outer loop
+      vertex 10.006 5.8528 3.00361
+      vertex 10.0096 5.80397 0.00999928
+      vertex 10.0024 5.90186 0.00999928
+    endloop
+  endfacet
+  facet normal -0.49291 0.87008 0
+    outer loop
+      vertex 12.9428 4.23616 0.00999928
+      vertex 13.0282 4.28454 3.53992
+      vertex 13.0282 4.28454 0.00999928
+    endloop
+  endfacet
+  facet normal -0.49291 0.87008 0
+    outer loop
+      vertex 13.0282 4.28454 3.53992
+      vertex 12.9428 4.23616 0.00999928
+      vertex 12.9428 4.23616 3.574
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex 13.1914 4.39358 0.00999928
+      vertex 13.2688 4.45398 3.42917
+      vertex 13.2688 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal -0.615209 0.788364 0
+    outer loop
+      vertex 13.2688 4.45398 3.42917
+      vertex 13.1914 4.39358 0.00999928
+      vertex 13.1914 4.39358 3.46741
+    endloop
+  endfacet
+  facet normal 0.844461 0.535616 -0
+    outer loop
+      vertex 10.3371 4.88886 0.00999928
+      vertex 10.2845 4.97179 3.18213
+      vertex 10.3371 4.88886 3.21412
+    endloop
+  endfacet
+  facet normal 0.844461 0.535616 0
+    outer loop
+      vertex 10.2845 4.97179 3.18213
+      vertex 10.3371 4.88886 0.00999928
+      vertex 10.2845 4.97179 0.00999928
+    endloop
+  endfacet
+  facet normal 0.817707 -0.575635 0
+    outer loop
+      vertex 10.3371 7.11114 3.01
+      vertex 10.3936 7.1914 0.00999928
+      vertex 10.3936 7.1914 3.01
+    endloop
+  endfacet
+  facet normal 0.817707 -0.575635 0
+    outer loop
+      vertex 10.3936 7.1914 0.00999928
+      vertex 10.3371 7.11114 3.01
+      vertex 10.3371 7.11114 0.00999928
+    endloop
+  endfacet
+  facet normal 0.949505 -0.313751 0
+    outer loop
+      vertex 10.0861 6.58057 3.01
+      vertex 10.1169 6.67378 0.00999928
+      vertex 10.1169 6.67378 3.01
+    endloop
+  endfacet
+  facet normal 0.949505 -0.313751 0
+    outer loop
+      vertex 10.1169 6.67378 0.00999928
+      vertex 10.0861 6.58057 3.01
+      vertex 10.0861 6.58057 0.00999928
+    endloop
+  endfacet
+  facet normal 0.405401 0.914139 -0
+    outer loop
+      vertex 11.2346 4.15224 0.00999928
+      vertex 11.1449 4.19202 3.60667
+      vertex 11.2346 4.15224 3.63772
+    endloop
+  endfacet
+  facet normal 0.405401 0.914139 0
+    outer loop
+      vertex 11.1449 4.19202 3.60667
+      vertex 11.2346 4.15224 0.00999928
+      vertex 11.1449 4.19202 0.00999928
+    endloop
+  endfacet
+  facet normal 0.975411 0.220393 -4.57252e-05
+    outer loop
+      vertex 10.0599 5.51404 0.00999928
+      vertex 10.0384 5.60982 3.0263
+      vertex 10.0497 5.55981 3.03247
+    endloop
+  endfacet
+  facet normal 0.976056 0.217517 -0
+    outer loop
+      vertex 10.0599 5.51404 0.00999928
+      vertex 10.0497 5.55981 3.03247
+      vertex 10.0599 5.51404 3.04041
+    endloop
+  endfacet
+  facet normal 0.97572 0.219023 0
+    outer loop
+      vertex 10.0384 5.60982 3.0263
+      vertex 10.0599 5.51404 0.00999928
+      vertex 10.0384 5.60982 0.00999928
+    endloop
+  endfacet
+  facet normal 0.0245594 0.999698 -0
+    outer loop
+      vertex 12 4 0.00999928
+      vertex 11.9019 4.00241 3.76241
+      vertex 12 4 3.76449
+    endloop
+  endfacet
+  facet normal 0.0245594 0.999698 0
+    outer loop
+      vertex 11.9019 4.00241 3.76241
+      vertex 12 4 0.00999928
+      vertex 11.9019 4.00241 0.00999928
+    endloop
+  endfacet
+  facet normal 0.892956 -0.450144 0
+    outer loop
+      vertex 10.192 6.85511 3.01
+      vertex 10.2362 6.94279 0.00999928
+      vertex 10.2362 6.94279 3.01
+    endloop
+  endfacet
+  facet normal 0.892956 -0.450144 0
+    outer loop
+      vertex 10.2362 6.94279 0.00999928
+      vertex 10.192 6.85511 3.01
+      vertex 10.192 6.85511 0.00999928
+    endloop
+  endfacet
+  facet normal 0.073549 0.997292 -0
+    outer loop
+      vertex 11.9019 4.00241 0.00999928
+      vertex 11.804 4.00963 3.75618
+      vertex 11.9019 4.00241 3.76241
+    endloop
+  endfacet
+  facet normal 0.073549 0.997292 0
+    outer loop
+      vertex 11.804 4.00963 3.75618
+      vertex 11.9019 4.00241 0.00999928
+      vertex 11.804 4.00963 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985248 0.171135 0
+    outer loop
+      vertex 13.9616 5.60982 0.00999928
+      vertex 13.9784 5.70654 3.0144
+      vertex 13.9784 5.70654 0.00999928
+    endloop
+  endfacet
+  facet normal -0.985937 0.167119 0.000133127
+    outer loop
+      vertex 13.9784 5.70654 3.0144
+      vertex 13.9616 5.60982 0.00999928
+      vertex 13.9783 5.70595 3.01445
+    endloop
+  endfacet
+  facet normal -0.985243 0.17116 0
+    outer loop
+      vertex 13.9783 5.70595 3.01445
+      vertex 13.9616 5.60982 0.00999928
+      vertex 13.9616 5.60982 3.0263
+    endloop
+  endfacet
+  facet normal 0.575579 0.817746 -0
+    outer loop
+      vertex 10.8889 4.33706 0.00999928
+      vertex 10.8086 4.39358 3.46741
+      vertex 10.8889 4.33706 3.5032
+    endloop
+  endfacet
+  facet normal 0.575579 0.817746 0
+    outer loop
+      vertex 10.8086 4.39358 3.46741
+      vertex 10.8889 4.33706 0.00999928
+      vertex 10.8086 4.39358 0.00999928
+    endloop
+  endfacet
+  facet normal 0.97572 -0.219023 0
+    outer loop
+      vertex 10.0384 6.39018 3.01
+      vertex 10.0599 6.48596 0.00999928
+      vertex 10.0599 6.48596 3.01
+    endloop
+  endfacet
+  facet normal 0.97572 -0.219023 0
+    outer loop
+      vertex 10.0599 6.48596 0.00999928
+      vertex 10.0384 6.39018 3.01
+      vertex 10.0384 6.39018 0.00999928
+    endloop
+  endfacet
+  facet normal 0.870455 -0.492249 0
+    outer loop
+      vertex 10.2362 6.94279 3.01
+      vertex 10.2845 7.0282 0.00999928
+      vertex 10.2845 7.0282 3.01
+    endloop
+  endfacet
+  facet normal 0.870455 -0.492249 0
+    outer loop
+      vertex 10.2845 7.0282 0.00999928
+      vertex 10.2362 6.94279 3.01
+      vertex 10.2362 6.94279 0.00999928
+    endloop
+  endfacet
+  facet normal 0.266719 -0.963774 0
+    outer loop
+      vertex 11.4194 7.91388 0.00999928
+      vertex 11.514 7.94006 3.01
+      vertex 11.4194 7.91388 3.01
+    endloop
+  endfacet
+  facet normal 0.266719 -0.963774 0
+    outer loop
+      vertex 11.514 7.94006 3.01
+      vertex 11.4194 7.91388 0.00999928
+      vertex 11.514 7.94006 0.00999928
+    endloop
+  endfacet
+  facet normal 0.999701 -0.02445 0
+    outer loop
+      vertex 10 6 3
+      vertex 10.0024 6.09813 0.00999928
+      vertex 10.0024 6.09813 3.00241
+    endloop
+  endfacet
+  facet normal 0.999701 -0.02445 0
+    outer loop
+      vertex 10.0024 6.09813 0.00999928
+      vertex 10 6 3
+      vertex 10 6 0.00999928
+    endloop
+  endfacet
+  facet normal 0.757297 -0.653071 0
+    outer loop
+      vertex 10.454 7.26879 3.01
+      vertex 10.5181 7.34312 0.00999928
+      vertex 10.5181 7.34312 3.01
+    endloop
+  endfacet
+  facet normal 0.757297 -0.653071 0
+    outer loop
+      vertex 10.5181 7.34312 0.00999928
+      vertex 10.454 7.26879 3.01
+      vertex 10.454 7.26879 0.00999928
+    endloop
+  endfacet
+  facet normal 0.535173 -0.844742 0
+    outer loop
+      vertex 10.8889 7.66294 0.00999928
+      vertex 10.9718 7.71546 3.01
+      vertex 10.8889 7.66294 3.01
+    endloop
+  endfacet
+  facet normal 0.535173 -0.844742 0
+    outer loop
+      vertex 10.9718 7.71546 3.01
+      vertex 10.8889 7.66294 0.00999928
+      vertex 10.9718 7.71546 0.00999928
+    endloop
+  endfacet
+  facet normal 0.653253 0.75714 -0
+    outer loop
+      vertex 10.7312 4.45398 0.00999928
+      vertex 10.7269 4.45769 3.42681
+      vertex 10.7312 4.45398 3.42917
+    endloop
+  endfacet
+  facet normal 0.653344 0.757061 1.9929e-07
+    outer loop
+      vertex 10.7312 4.45398 0.00999928
+      vertex 10.6569 4.5181 3.39259
+      vertex 10.7269 4.45769 3.42681
+    endloop
+  endfacet
+  facet normal 0.653339 0.757066 0
+    outer loop
+      vertex 10.6569 4.5181 3.39259
+      vertex 10.7312 4.45398 0.00999928
+      vertex 10.6569 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal 0.997293 -0.0735256 0
+    outer loop
+      vertex 10.006 6.1472 3.00361
+      vertex 10.0096 6.19603 0.00999928
+      vertex 10.0096 6.19603 3.00722
+    endloop
+  endfacet
+  facet normal 0.99732 -0.0731681 5.86359e-06
+    outer loop
+      vertex 10.0024 6.09813 3.00241
+      vertex 10.0096 6.19603 0.00999928
+      vertex 10.006 6.1472 3.00361
+    endloop
+  endfacet
+  facet normal 0.997307 -0.0733463 0
+    outer loop
+      vertex 10.0096 6.19603 0.00999928
+      vertex 10.0024 6.09813 3.00241
+      vertex 10.0024 6.09813 0.00999928
+    endloop
+  endfacet
+  facet normal 0.31369 -0.949526 0
+    outer loop
+      vertex 11.3262 7.88309 0.00999928
+      vertex 11.4194 7.91388 3.01
+      vertex 11.3262 7.88309 3.01
+    endloop
+  endfacet
+  facet normal 0.31369 -0.949526 0
+    outer loop
+      vertex 11.4194 7.91388 3.01
+      vertex 11.3262 7.88309 0.00999928
+      vertex 11.4194 7.91388 0.00999928
+    endloop
+  endfacet
+  facet normal -0.170971 -0.985276 0
+    outer loop
+      vertex 12.2935 7.97835 0.00999928
+      vertex 12.3902 7.96157 3.01
+      vertex 12.2935 7.97835 3.01
+    endloop
+  endfacet
+  facet normal -0.170971 -0.985276 -0
+    outer loop
+      vertex 12.3902 7.96157 3.01
+      vertex 12.2935 7.97835 0.00999928
+      vertex 12.3902 7.96157 0.00999928
+    endloop
+  endfacet
+  facet normal 0.756488 0.654008 -3.71393e-05
+    outer loop
+      vertex 10.5181 4.65688 0.00999928
+      vertex 10.454 4.73121 3.28188
+      vertex 10.466 4.71733 3.28803
+    endloop
+  endfacet
+  facet normal 0.757485 0.652853 -0
+    outer loop
+      vertex 10.5181 4.65688 0.00999928
+      vertex 10.466 4.71733 3.28803
+      vertex 10.5181 4.65688 3.31846
+    endloop
+  endfacet
+  facet normal 0.757297 0.653071 0
+    outer loop
+      vertex 10.454 4.73121 3.28188
+      vertex 10.5181 4.65688 0.00999928
+      vertex 10.454 4.73121 0.00999928
+    endloop
+  endfacet
+  facet normal -0.653339 0.757066 0
+    outer loop
+      vertex 13.2688 4.45398 0.00999928
+      vertex 13.3431 4.5181 3.39259
+      vertex 13.3431 4.5181 0.00999928
+    endloop
+  endfacet
+  facet normal -0.653344 0.757061 1.9929e-07
+    outer loop
+      vertex 13.3431 4.5181 3.39259
+      vertex 13.2688 4.45398 0.00999928
+      vertex 13.2731 4.45769 3.42681
+    endloop
+  endfacet
+  facet normal -0.653253 0.75714 0
+    outer loop
+      vertex 13.2731 4.45769 3.42681
+      vertex 13.2688 4.45398 0.00999928
+      vertex 13.2688 4.45398 3.42917
+    endloop
+  endfacet
+  facet normal -0.219076 -0.975708 0
+    outer loop
+      vertex 12.3902 7.96157 0.00999928
+      vertex 12.486 7.94006 3.01
+      vertex 12.3902 7.96157 3.01
+    endloop
+  endfacet
+  facet normal -0.219076 -0.975708 -0
+    outer loop
+      vertex 12.486 7.94006 3.01
+      vertex 12.3902 7.96157 0.00999928
+      vertex 12.486 7.94006 0.00999928
+    endloop
+  endfacet
+  facet normal 0.933096 -0.359628 0
+    outer loop
+      vertex 10.1169 6.67378 3.01
+      vertex 10.1522 6.76537 0.00999928
+      vertex 10.1522 6.76537 3.01
+    endloop
+  endfacet
+  facet normal 0.933096 -0.359628 0
+    outer loop
+      vertex 10.1522 6.76537 0.00999928
+      vertex 10.1169 6.67378 3.01
+      vertex 10.1169 6.67378 0.00999928
+    endloop
+  endfacet
+  facet normal 0.615209 0.788364 -0
+    outer loop
+      vertex 10.8086 4.39358 0.00999928
+      vertex 10.7312 4.45398 3.42917
+      vertex 10.8086 4.39358 3.46741
+    endloop
+  endfacet
+  facet normal 0.615209 0.788364 0
+    outer loop
+      vertex 10.7312 4.45398 3.42917
+      vertex 10.8086 4.39358 0.00999928
+      vertex 10.7312 4.45398 0.00999928
+    endloop
+  endfacet
+  facet normal 0.946665 0.322219 -0.000287769
+    outer loop
+      vertex 10.1169 5.32622 0.00999928
+      vertex 10.0861 5.41943 3.05683
+      vertex 10.0877 5.41473 3.05764
+    endloop
+  endfacet
+  facet normal 0.949655 0.313297 -0
+    outer loop
+      vertex 10.1169 5.32622 0.00999928
+      vertex 10.0877 5.41473 3.05764
+      vertex 10.1169 5.32622 3.07752
+    endloop
+  endfacet
+  facet normal 0.949505 0.313751 0
+    outer loop
+      vertex 10.0861 5.41943 3.05683
+      vertex 10.1169 5.32622 0.00999928
+      vertex 10.0861 5.41943 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 0.40542 0
+    outer loop
+      vertex 13.808 5.14489 0.00999928
+      vertex 13.8478 5.23463 3.09999
+      vertex 13.8478 5.23463 0.00999928
+    endloop
+  endfacet
+  facet normal -0.914131 0.40542 0
+    outer loop
+      vertex 13.8478 5.23463 3.09999
+      vertex 13.808 5.14489 0.00999928
+      vertex 13.808 5.14489 3.12482
+    endloop
+  endfacet
+  facet normal -0.933096 0.359628 0
+    outer loop
+      vertex 13.8478 5.23463 0.00999928
+      vertex 13.8831 5.32622 3.07752
+      vertex 13.8831 5.32622 0.00999928
+    endloop
+  endfacet
+  facet normal -0.932867 0.360221 -2.03672e-05
+    outer loop
+      vertex 13.8831 5.32622 3.07752
+      vertex 13.8478 5.23463 0.00999928
+      vertex 13.8618 5.27106 3.08991
+    endloop
+  endfacet
+  facet normal -0.933445 0.358722 0
+    outer loop
+      vertex 13.8618 5.27106 3.08991
+      vertex 13.8478 5.23463 0.00999928
+      vertex 13.8478 5.23463 3.09999
+    endloop
+  endfacet
+  facet normal 0.914131 -0.40542 0
+    outer loop
+      vertex 10.1522 6.76537 3.01
+      vertex 10.192 6.85511 0.00999928
+      vertex 10.192 6.85511 3.01
+    endloop
+  endfacet
+  facet normal 0.914131 -0.40542 0
+    outer loop
+      vertex 10.192 6.85511 0.00999928
+      vertex 10.1522 6.76537 3.01
+      vertex 10.1522 6.76537 0.00999928
+    endloop
+  endfacet
+  facet normal 0.893739 0.448588 5.49163e-05
+    outer loop
+      vertex 10.2362 5.05721 0.00999928
+      vertex 10.192 5.14489 3.12482
+      vertex 10.1999 5.12915 3.12918
+    endloop
+  endfacet
+  facet normal 0.892783 0.450487 -0
+    outer loop
+      vertex 10.2362 5.05721 0.00999928
+      vertex 10.1999 5.12915 3.12918
+      vertex 10.2362 5.05721 3.15294
+    endloop
+  endfacet
+  facet normal 0.892956 0.450144 0
+    outer loop
+      vertex 10.192 5.14489 3.12482
+      vertex 10.2362 5.05721 0.00999928
+      vertex 10.192 5.14489 0.00999928
+    endloop
+  endfacet
+  facet normal 0.49291 0.87008 -0
+    outer loop
+      vertex 11.0572 4.23616 0.00999928
+      vertex 10.9718 4.28454 3.53992
+      vertex 11.0572 4.23616 3.574
+    endloop
+  endfacet
+  facet normal 0.49291 0.87008 0
+    outer loop
+      vertex 10.9718 4.28454 3.53992
+      vertex 11.0572 4.23616 0.00999928
+      vertex 10.9718 4.28454 0.00999928
+    endloop
+  endfacet
+  facet normal 0.449575 -0.893243 0
+    outer loop
+      vertex 11.0572 7.76384 0.00999928
+      vertex 11.1449 7.80798 3.01
+      vertex 11.0572 7.76384 3.01
+    endloop
+  endfacet
+  facet normal 0.449575 -0.893243 0
+    outer loop
+      vertex 11.1449 7.80798 3.01
+      vertex 11.0572 7.76384 0.00999928
+      vertex 11.1449 7.80798 0.00999928
+    endloop
+  endfacet
+  facet normal 0.870382 0.492377 -6.16218e-06
+    outer loop
+      vertex 10.2845 4.97179 0.00999928
+      vertex 10.2362 5.05721 3.15294
+      vertex 10.2746 4.98933 3.17537
+    endloop
+  endfacet
+  facet normal 0.870859 0.491534 -0
+    outer loop
+      vertex 10.2845 4.97179 0.00999928
+      vertex 10.2746 4.98933 3.17537
+      vertex 10.2845 4.97179 3.18213
+    endloop
+  endfacet
+  facet normal 0.870479 0.492205 0
+    outer loop
+      vertex 10.2362 5.05721 3.15294
+      vertex 10.2845 4.97179 0.00999928
+      vertex 10.2362 5.05721 0.00999928
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 -4 0.01
+      vertex -6.25 0 0.01
+      vertex -6.25 -4 0.01
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.25 0 0.01
+      vertex -10 -4 0.01
+      vertex -10 0 0.01
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.25 -4 0.01
+      vertex 10 0 0.01
+      vertex 10 -4 0.01
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10 0 0.01
+      vertex 6.25 -4 0.01
+      vertex 6.25 0 0.01
+    endloop
+  endfacet
+  facet normal -0.999283 0 -0.0378516
+    outer loop
+      vertex -10 -4 0.01
+      vertex -10.5 0 13.21
+      vertex -10 0 0.01
+    endloop
+  endfacet
+  facet normal -0.999283 -0 -0.0378516
+    outer loop
+      vertex -10.5 0 13.21
+      vertex -10 -4 0.01
+      vertex -10.5 -4 13.21
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.5 0 13.21
+      vertex 10.5 -4 13.21
+      vertex 10.5 0 13.21
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 -4 13.21
+      vertex -10.5 0 13.21
+      vertex -10.5 -4 13.21
+    endloop
+  endfacet
+  facet normal 0.999283 0 -0.0378516
+    outer loop
+      vertex 10.5 -4 13.21
+      vertex 10 0 0.01
+      vertex 10.5 0 13.21
+    endloop
+  endfacet
+  facet normal 0.999283 0 -0.0378516
+    outer loop
+      vertex 10 0 0.01
+      vertex 10.5 -4 13.21
+      vertex 10 -4 0.01
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -10 -4 13.21
+      vertex -10.5 -4 13.21
       vertex -6.25 -4 11.6
-      vertex 10 -4 13.21
+      vertex 10.5 -4 13.21
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -10 -4 0.00999928
+      vertex -10 -4 0.01
       vertex -6.25 -4 11.6
-      vertex -10 -4 13.21
+      vertex -10.5 -4 13.21
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
       vertex -6.25 -4 11.6
-      vertex -10 -4 0.00999928
-      vertex -6.25 -4 0.00999928
+      vertex -10 -4 0.01
+      vertex -6.25 -4 0.01
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex 6.25 -4 11.6
-      vertex 10 -4 13.21
+      vertex 10.5 -4 13.21
       vertex -6.25 -4 11.6
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 10 -4 0.00999928
+      vertex 10 -4 0.01
       vertex 6.25 -4 11.6
-      vertex 6.25 -4 0.00999928
+      vertex 6.25 -4 0.01
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex 6.25 -4 11.6
-      vertex 10 -4 0.00999928
-      vertex 10 -4 13.21
+      vertex 10 -4 0.01
+      vertex 10.5 -4 13.21
     endloop
   endfacet
   facet normal -0 0 1
@@ -9897,4050 +13957,32 @@ solid OpenSCAD_Model
       vertex -16 3 6
     endloop
   endfacet
-  facet normal -0.870455 -0.492249 0
-    outer loop
-      vertex -10.2362 6.94279 0.00999928
-      vertex -10.2845 7.0282 3.01
-      vertex -10.2845 7.0282 0.00999928
-    endloop
-  endfacet
-  facet normal -0.870455 -0.492249 0
-    outer loop
-      vertex -10.2845 7.0282 3.01
-      vertex -10.2362 6.94279 0.00999928
-      vertex -10.2362 6.94279 3.01
-    endloop
-  endfacet
-  facet normal 0.0245594 -0.999698 0
-    outer loop
-      vertex -12.0981 7.99759 0.00999928
-      vertex -12 8 3.01
-      vertex -12.0981 7.99759 3.01
-    endloop
-  endfacet
-  facet normal 0.0245594 -0.999698 0
-    outer loop
-      vertex -12 8 3.01
-      vertex -12.0981 7.99759 0.00999928
-      vertex -12 8 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244476 0
-    outer loop
-      vertex -10.0024 5.90186 0.00999928
-      vertex -10 6 3
-      vertex -10 6 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244476 0
-    outer loop
-      vertex -10 6 3
-      vertex -10.0024 5.90186 0.00999928
-      vertex -10.0024 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal -0.963729 0.266882 0
-    outer loop
-      vertex -10.0861 5.41943 0.00999928
-      vertex -10.0599 5.51404 3.04041
-      vertex -10.0599 5.51404 0.00999928
-    endloop
-  endfacet
-  facet normal -0.963729 0.266882 0
-    outer loop
-      vertex -10.0599 5.51404 3.04041
-      vertex -10.0861 5.41943 0.00999928
-      vertex -10.0861 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0.653253 0.75714 -0
-    outer loop
-      vertex -13.2688 4.45398 0.00999928
-      vertex -13.2731 4.45769 3.42681
-      vertex -13.2688 4.45398 3.42917
-    endloop
-  endfacet
-  facet normal 0.653344 0.757061 1.9929e-07
-    outer loop
-      vertex -13.2688 4.45398 0.00999928
-      vertex -13.3431 4.5181 3.39259
-      vertex -13.2731 4.45769 3.42681
-    endloop
-  endfacet
-  facet normal 0.653339 0.757066 0
-    outer loop
-      vertex -13.3431 4.5181 3.39259
-      vertex -13.2688 4.45398 0.00999928
-      vertex -13.3431 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal 0.870455 -0.492249 0
-    outer loop
-      vertex -13.7638 6.94279 3.01
-      vertex -13.7155 7.0282 0.00999928
-      vertex -13.7155 7.0282 3.01
-    endloop
-  endfacet
-  facet normal 0.870455 -0.492249 0
-    outer loop
-      vertex -13.7155 7.0282 0.00999928
-      vertex -13.7638 6.94279 3.01
-      vertex -13.7638 6.94279 0.00999928
-    endloop
-  endfacet
-  facet normal 0.817534 0.575881 -9.2087e-06
-    outer loop
-      vertex -13.6064 4.8086 0.00999928
-      vertex -13.6629 4.88886 3.21412
-      vertex -13.6369 4.85195 3.22836
-    endloop
-  endfacet
-  facet normal 0.817856 0.575423 -0
-    outer loop
-      vertex -13.6064 4.8086 0.00999928
-      vertex -13.6369 4.85195 3.22836
-      vertex -13.6064 4.8086 3.24758
-    endloop
-  endfacet
-  facet normal 0.817707 0.575635 0
-    outer loop
-      vertex -13.6629 4.88886 3.21412
-      vertex -13.6064 4.8086 0.00999928
-      vertex -13.6629 4.88886 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575647 -0.817698 0
-    outer loop
-      vertex -10.8889 7.66294 0.00999928
-      vertex -10.8086 7.60641 3.01
-      vertex -10.8889 7.66294 3.01
-    endloop
-  endfacet
-  facet normal -0.575647 -0.817698 -0
-    outer loop
-      vertex -10.8086 7.60641 3.01
-      vertex -10.8889 7.66294 0.00999928
-      vertex -10.8086 7.60641 0.00999928
-    endloop
-  endfacet
-  facet normal -0.817707 0.575635 0
-    outer loop
-      vertex -10.3936 4.8086 0.00999928
-      vertex -10.3371 4.88886 3.21412
-      vertex -10.3371 4.88886 0.00999928
-    endloop
-  endfacet
-  facet normal -0.817534 0.575881 -9.2087e-06
-    outer loop
-      vertex -10.3371 4.88886 3.21412
-      vertex -10.3936 4.8086 0.00999928
-      vertex -10.3631 4.85195 3.22836
-    endloop
-  endfacet
-  facet normal -0.817856 0.575423 0
-    outer loop
-      vertex -10.3631 4.85195 3.22836
-      vertex -10.3936 4.8086 0.00999928
-      vertex -10.3936 4.8086 3.24758
-    endloop
-  endfacet
-  facet normal 0.999701 0.0244476 -0
-    outer loop
-      vertex -13.9976 5.90186 0.00999928
-      vertex -14 6 3
-      vertex -13.9976 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal 0.999701 0.0244476 0
-    outer loop
-      vertex -14 6 3
-      vertex -13.9976 5.90186 0.00999928
-      vertex -14 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0.992172 -0.121362 -0.0294284
-    outer loop
-      vertex -13.9904 6.19603 3.00722
-      vertex -13.9784 6.29346 3.01
-      vertex -13.9857 6.23378 3.01
-    endloop
-  endfacet
-  facet normal 0.9925 -0.122242 0
-    outer loop
-      vertex -13.9784 6.29346 3.01
-      vertex -13.9904 6.19603 3.00722
-      vertex -13.9784 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal 0.9925 -0.122242 0
-    outer loop
-      vertex -13.9784 6.29346 0.00999928
-      vertex -13.9904 6.19603 3.00722
-      vertex -13.9904 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal 0.946665 0.322219 -0.000287769
-    outer loop
-      vertex -13.8831 5.32622 0.00999928
-      vertex -13.9139 5.41943 3.05683
-      vertex -13.9123 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal 0.949655 0.313297 -0
-    outer loop
-      vertex -13.8831 5.32622 0.00999928
-      vertex -13.9123 5.41473 3.05764
-      vertex -13.8831 5.32622 3.07752
-    endloop
-  endfacet
-  facet normal 0.949505 0.313751 0
-    outer loop
-      vertex -13.9139 5.41943 3.05683
-      vertex -13.8831 5.32622 0.00999928
-      vertex -13.9139 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal 0.724066 0.68973 -4.12488e-06
-    outer loop
-      vertex -13.4142 4.58579 0.00999928
-      vertex -13.4819 4.65688 3.31846
-      vertex -13.4142 4.58581 3.35424
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -13.4142 4.58579 0.00999928
-      vertex -13.4142 4.58581 3.35424
-      vertex -13.4142 4.58579 3.35425
-    endloop
-  endfacet
-  facet normal 0.724162 0.68963 0
-    outer loop
-      vertex -13.4819 4.65688 3.31846
-      vertex -13.4142 4.58579 0.00999928
-      vertex -13.4819 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal -0.170971 -0.985276 0
-    outer loop
-      vertex -11.7065 7.97835 0.00999928
-      vertex -11.6098 7.96157 3.01
-      vertex -11.7065 7.97835 3.01
-    endloop
-  endfacet
-  facet normal -0.170971 -0.985276 -0
-    outer loop
-      vertex -11.6098 7.96157 3.01
-      vertex -11.7065 7.97835 0.00999928
-      vertex -11.6098 7.96157 0.00999928
-    endloop
-  endfacet
-  facet normal 0.575647 -0.817698 0
-    outer loop
-      vertex -13.1914 7.60641 0.00999928
-      vertex -13.1111 7.66294 3.01
-      vertex -13.1914 7.60641 3.01
-    endloop
-  endfacet
-  facet normal 0.575647 -0.817698 0
-    outer loop
-      vertex -13.1111 7.66294 3.01
-      vertex -13.1914 7.60641 0.00999928
-      vertex -13.1111 7.66294 0.00999928
-    endloop
-  endfacet
-  facet normal -0.997293 -0.0735256 0
-    outer loop
-      vertex -10.0096 6.19603 0.00999928
-      vertex -10.006 6.1472 3.00361
-      vertex -10.0096 6.19603 3.00722
-    endloop
-  endfacet
-  facet normal -0.997307 -0.0733463 2.94012e-06
-    outer loop
-      vertex -10.0024 6.09813 0.00999928
-      vertex -10.006 6.1472 3.00361
-      vertex -10.0096 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal -0.99732 -0.0731679 0
-    outer loop
-      vertex -10.006 6.1472 3.00361
-      vertex -10.0024 6.09813 0.00999928
-      vertex -10.0024 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal -0.997319 0.0731828 0
-    outer loop
-      vertex -10.0024 5.90186 0.00999928
-      vertex -10.006 5.8528 3.00361
-      vertex -10.0024 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal -0.997306 0.0733538 2.8179e-06
-    outer loop
-      vertex -10.0096 5.80397 0.00999928
-      vertex -10.006 5.8528 3.00361
-      vertex -10.0024 5.90186 0.00999928
-    endloop
-  endfacet
-  facet normal -0.997293 0.0735256 0
-    outer loop
-      vertex -10.006 5.8528 3.00361
-      vertex -10.0096 5.80397 0.00999928
-      vertex -10.0096 5.80397 3.00722
-    endloop
-  endfacet
-  facet normal 0.985248 -0.171135 0
-    outer loop
-      vertex -13.9784 6.29346 3.01
-      vertex -13.9616 6.39018 0.00999928
-      vertex -13.9616 6.39018 3.01
-    endloop
-  endfacet
-  facet normal 0.985248 -0.171135 0
-    outer loop
-      vertex -13.9616 6.39018 0.00999928
-      vertex -13.9784 6.29346 3.01
-      vertex -13.9784 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal 0.844461 0.535616 -0
-    outer loop
-      vertex -13.6629 4.88886 0.00999928
-      vertex -13.7155 4.97179 3.18213
-      vertex -13.6629 4.88886 3.21412
-    endloop
-  endfacet
-  facet normal 0.844461 0.535616 0
-    outer loop
-      vertex -13.7155 4.97179 3.18213
-      vertex -13.6629 4.88886 0.00999928
-      vertex -13.7155 4.97179 0.00999928
-    endloop
-  endfacet
-  facet normal 0.170971 -0.985276 0
-    outer loop
-      vertex -12.3902 7.96157 0.00999928
-      vertex -12.2935 7.97835 3.01
-      vertex -12.3902 7.96157 3.01
-    endloop
-  endfacet
-  facet normal 0.170971 -0.985276 0
-    outer loop
-      vertex -12.2935 7.97835 3.01
-      vertex -12.3902 7.96157 0.00999928
-      vertex -12.2935 7.97835 0.00999928
-    endloop
-  endfacet
-  facet normal 0.844491 -0.53557 0
-    outer loop
-      vertex -13.7155 7.0282 3.01
-      vertex -13.6629 7.11114 0.00999928
-      vertex -13.6629 7.11114 3.01
-    endloop
-  endfacet
-  facet normal 0.844491 -0.53557 0
-    outer loop
-      vertex -13.6629 7.11114 0.00999928
-      vertex -13.7155 7.0282 3.01
-      vertex -13.7155 7.0282 0.00999928
-    endloop
-  endfacet
-  facet normal 0.949505 -0.313751 0
-    outer loop
-      vertex -13.9139 6.58057 3.01
-      vertex -13.8831 6.67378 0.00999928
-      vertex -13.8831 6.67378 3.01
-    endloop
-  endfacet
-  facet normal 0.949505 -0.313751 0
-    outer loop
-      vertex -13.8831 6.67378 0.00999928
-      vertex -13.9139 6.58057 3.01
-      vertex -13.9139 6.58057 0.00999928
-    endloop
-  endfacet
-  facet normal -0.49291 0.87008 0
-    outer loop
-      vertex -11.0572 4.23616 0.00999928
-      vertex -10.9718 4.28454 3.53992
-      vertex -10.9718 4.28454 0.00999928
-    endloop
-  endfacet
-  facet normal -0.49291 0.87008 0
-    outer loop
-      vertex -10.9718 4.28454 3.53992
-      vertex -11.0572 4.23616 0.00999928
-      vertex -11.0572 4.23616 3.574
-    endloop
-  endfacet
-  facet normal -0.724162 -0.68963 0
-    outer loop
-      vertex -10.5181 7.34312 0.00999928
-      vertex -10.5858 7.41421 3.01
-      vertex -10.5858 7.41421 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724162 -0.68963 0
-    outer loop
-      vertex -10.5858 7.41421 3.01
-      vertex -10.5181 7.34312 0.00999928
-      vertex -10.5181 7.34312 3.01
-    endloop
-  endfacet
-  facet normal 0.985937 0.167119 0.000133127
-    outer loop
-      vertex -13.9616 5.60982 0.00999928
-      vertex -13.9784 5.70654 3.0144
-      vertex -13.9783 5.70595 3.01445
-    endloop
-  endfacet
-  facet normal 0.985243 0.17116 -0
-    outer loop
-      vertex -13.9616 5.60982 0.00999928
-      vertex -13.9783 5.70595 3.01445
-      vertex -13.9616 5.60982 3.0263
-    endloop
-  endfacet
-  facet normal 0.985248 0.171135 0
-    outer loop
-      vertex -13.9784 5.70654 3.0144
-      vertex -13.9616 5.60982 0.00999928
-      vertex -13.9784 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal 0.757297 -0.653071 0
-    outer loop
-      vertex -13.546 7.26879 3.01
-      vertex -13.4819 7.34312 0.00999928
-      vertex -13.4819 7.34312 3.01
-    endloop
-  endfacet
-  facet normal 0.757297 -0.653071 0
-    outer loop
-      vertex -13.4819 7.34312 0.00999928
-      vertex -13.546 7.26879 3.01
-      vertex -13.546 7.26879 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 0.653071 0
-    outer loop
-      vertex -10.5181 4.65688 0.00999928
-      vertex -10.454 4.73121 3.28188
-      vertex -10.454 4.73121 0.00999928
-    endloop
-  endfacet
-  facet normal -0.756488 0.654008 -3.71393e-05
-    outer loop
-      vertex -10.454 4.73121 3.28188
-      vertex -10.5181 4.65688 0.00999928
-      vertex -10.466 4.71733 3.28803
-    endloop
-  endfacet
-  facet normal -0.757485 0.652853 0
-    outer loop
-      vertex -10.466 4.71733 3.28803
-      vertex -10.5181 4.65688 0.00999928
-      vertex -10.5181 4.65688 3.31846
-    endloop
-  endfacet
-  facet normal 0.653339 -0.757066 0
-    outer loop
-      vertex -13.3431 7.4819 0.00999928
-      vertex -13.2688 7.54602 3.01
-      vertex -13.3431 7.4819 3.01
-    endloop
-  endfacet
-  facet normal 0.653339 -0.757066 0
-    outer loop
-      vertex -13.2688 7.54602 3.01
-      vertex -13.3431 7.4819 0.00999928
-      vertex -13.2688 7.54602 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 -0.02445 -0
-    outer loop
-      vertex -10 6 3
-      vertex -10.0024 6.09813 0.00999928
-      vertex -10 6 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 -0.02445 0
-    outer loop
-      vertex -10.0024 6.09813 0.00999928
-      vertex -10 6 3
-      vertex -10.0024 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal -0.073549 -0.997292 0
-    outer loop
-      vertex -11.9019 7.99759 0.00999928
-      vertex -11.804 7.99037 3.01
-      vertex -11.9019 7.99759 3.01
-    endloop
-  endfacet
-  facet normal -0.073549 -0.997292 -0
-    outer loop
-      vertex -11.804 7.99037 3.01
-      vertex -11.9019 7.99759 0.00999928
-      vertex -11.804 7.99037 0.00999928
-    endloop
-  endfacet
-  facet normal 0.073549 0.997292 -0
-    outer loop
-      vertex -12.0981 4.00241 0.00999928
-      vertex -12.196 4.00963 3.75618
-      vertex -12.0981 4.00241 3.76241
-    endloop
-  endfacet
-  facet normal 0.073549 0.997292 0
-    outer loop
-      vertex -12.196 4.00963 3.75618
-      vertex -12.0981 4.00241 0.00999928
-      vertex -12.196 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal 0.689525 -0.724261 0
-    outer loop
-      vertex -13.4142 7.41421 0.00999928
-      vertex -13.3431 7.4819 3.01
-      vertex -13.4142 7.41421 3.01
-    endloop
-  endfacet
-  facet normal 0.689525 -0.724261 0
-    outer loop
-      vertex -13.3431 7.4819 3.01
-      vertex -13.4142 7.41421 0.00999928
-      vertex -13.3431 7.4819 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575579 0.817746 0
-    outer loop
-      vertex -10.8889 4.33706 0.00999928
-      vertex -10.8086 4.39358 3.46741
-      vertex -10.8086 4.39358 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575579 0.817746 0
-    outer loop
-      vertex -10.8086 4.39358 3.46741
-      vertex -10.8889 4.33706 0.00999928
-      vertex -10.8889 4.33706 3.5032
-    endloop
-  endfacet
-  facet normal 0.0245594 0.999698 -0
-    outer loop
-      vertex -12 4 0.00999928
-      vertex -12.0981 4.00241 3.76241
-      vertex -12 4 3.76449
-    endloop
-  endfacet
-  facet normal 0.0245594 0.999698 0
-    outer loop
-      vertex -12.0981 4.00241 3.76241
-      vertex -12 4 0.00999928
-      vertex -12.0981 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal -0.949505 -0.313751 0
-    outer loop
-      vertex -10.0861 6.58057 0.00999928
-      vertex -10.1169 6.67378 3.01
-      vertex -10.1169 6.67378 0.00999928
-    endloop
-  endfacet
-  facet normal -0.949505 -0.313751 0
-    outer loop
-      vertex -10.1169 6.67378 3.01
-      vertex -10.0861 6.58057 0.00999928
-      vertex -10.0861 6.58057 3.01
-    endloop
-  endfacet
-  facet normal -0.9925 -0.122242 0
-    outer loop
-      vertex -10.0096 6.19603 3.00722
-      vertex -10.0216 6.29346 3.01
-      vertex -10.0216 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 -0.122242 -0
-    outer loop
-      vertex -10.0096 6.19603 3.00722
-      vertex -10.0216 6.29346 0.00999928
-      vertex -10.0096 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal -0.992172 -0.121362 -0.0294284
-    outer loop
-      vertex -10.0216 6.29346 3.01
-      vertex -10.0096 6.19603 3.00722
-      vertex -10.0143 6.23378 3.01
-    endloop
-  endfacet
-  facet normal -0.914131 -0.40542 0
-    outer loop
-      vertex -10.1522 6.76537 0.00999928
-      vertex -10.192 6.85511 3.01
-      vertex -10.192 6.85511 0.00999928
-    endloop
-  endfacet
-  facet normal -0.914131 -0.40542 0
-    outer loop
-      vertex -10.192 6.85511 3.01
-      vertex -10.1522 6.76537 0.00999928
-      vertex -10.1522 6.76537 3.01
-    endloop
-  endfacet
-  facet normal -0.689525 0.724261 0
-    outer loop
-      vertex -10.6569 4.5181 0.00999928
-      vertex -10.5858 4.58579 3.35425
-      vertex -10.5858 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal -0.689525 0.724261 0
-    outer loop
-      vertex -10.5858 4.58579 3.35425
-      vertex -10.6569 4.5181 0.00999928
-      vertex -10.6569 4.5181 3.39259
-    endloop
-  endfacet
-  facet normal -0.933096 0.359628 0
-    outer loop
-      vertex -10.1522 5.23463 0.00999928
-      vertex -10.1169 5.32622 3.07752
-      vertex -10.1169 5.32622 0.00999928
-    endloop
-  endfacet
-  facet normal -0.932867 0.360221 -2.03672e-05
-    outer loop
-      vertex -10.1169 5.32622 3.07752
-      vertex -10.1522 5.23463 0.00999928
-      vertex -10.1382 5.27106 3.08991
-    endloop
-  endfacet
-  facet normal -0.933445 0.358722 0
-    outer loop
-      vertex -10.1382 5.27106 3.08991
-      vertex -10.1522 5.23463 0.00999928
-      vertex -10.1522 5.23463 3.09999
-    endloop
-  endfacet
-  facet normal -0.535173 -0.844742 0
-    outer loop
-      vertex -10.9718 7.71546 0.00999928
-      vertex -10.8889 7.66294 3.01
-      vertex -10.9718 7.71546 3.01
-    endloop
-  endfacet
-  facet normal -0.535173 -0.844742 -0
-    outer loop
-      vertex -10.8889 7.66294 3.01
-      vertex -10.9718 7.71546 0.00999928
-      vertex -10.8889 7.66294 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653339 -0.757066 0
-    outer loop
-      vertex -10.7312 7.54602 0.00999928
-      vertex -10.6569 7.4819 3.01
-      vertex -10.7312 7.54602 3.01
-    endloop
-  endfacet
-  facet normal -0.653339 -0.757066 -0
-    outer loop
-      vertex -10.6569 7.4819 3.01
-      vertex -10.7312 7.54602 0.00999928
-      vertex -10.6569 7.4819 0.00999928
-    endloop
-  endfacet
-  facet normal 0.313589 0.949559 -0
-    outer loop
-      vertex -12.5806 4.08612 0.00999928
-      vertex -12.613 4.09682 3.68097
-      vertex -12.5806 4.08612 3.6902
-    endloop
-  endfacet
-  facet normal 0.313743 0.949508 1.51104e-06
-    outer loop
-      vertex -12.5806 4.08612 0.00999928
-      vertex -12.6738 4.11691 3.66529
-      vertex -12.613 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal 0.31369 0.949526 0
-    outer loop
-      vertex -12.6738 4.11691 3.66529
-      vertex -12.5806 4.08612 0.00999928
-      vertex -12.6738 4.11691 0.00999928
-    endloop
-  endfacet
-  facet normal -0.31369 0.949526 0
-    outer loop
-      vertex -11.4194 4.08612 0.00999928
-      vertex -11.3262 4.11691 3.66529
-      vertex -11.3262 4.11691 0.00999928
-    endloop
-  endfacet
-  facet normal -0.313743 0.949508 1.51104e-06
-    outer loop
-      vertex -11.3262 4.11691 3.66529
-      vertex -11.4194 4.08612 0.00999928
-      vertex -11.387 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal -0.313589 0.949559 0
-    outer loop
-      vertex -11.387 4.09682 3.68097
-      vertex -11.4194 4.08612 0.00999928
-      vertex -11.4194 4.08612 3.6902
-    endloop
-  endfacet
-  facet normal 0.756488 0.654008 -3.71393e-05
-    outer loop
-      vertex -13.4819 4.65688 0.00999928
-      vertex -13.546 4.73121 3.28188
-      vertex -13.534 4.71733 3.28803
-    endloop
-  endfacet
-  facet normal 0.757485 0.652853 -0
-    outer loop
-      vertex -13.4819 4.65688 0.00999928
-      vertex -13.534 4.71733 3.28803
-      vertex -13.4819 4.65688 3.31846
-    endloop
-  endfacet
-  facet normal 0.757297 0.653071 0
-    outer loop
-      vertex -13.546 4.73121 3.28188
-      vertex -13.4819 4.65688 0.00999928
-      vertex -13.546 4.73121 0.00999928
-    endloop
-  endfacet
-  facet normal -0.97572 0.219023 0
-    outer loop
-      vertex -10.0599 5.51404 0.00999928
-      vertex -10.0384 5.60982 3.0263
-      vertex -10.0384 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal -0.975411 0.220393 -4.57252e-05
-    outer loop
-      vertex -10.0384 5.60982 3.0263
-      vertex -10.0599 5.51404 0.00999928
-      vertex -10.0497 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal -0.976056 0.217517 0
-    outer loop
-      vertex -10.0497 5.55981 3.03247
-      vertex -10.0599 5.51404 0.00999928
-      vertex -10.0599 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal 0.170971 0.985276 -0
-    outer loop
-      vertex -12.2935 4.02165 0.00999928
-      vertex -12.3902 4.03843 3.73134
-      vertex -12.2935 4.02165 3.74581
-    endloop
-  endfacet
-  facet normal 0.170971 0.985276 0
-    outer loop
-      vertex -12.3902 4.03843 3.73134
-      vertex -12.2935 4.02165 0.00999928
-      vertex -12.3902 4.03843 0.00999928
-    endloop
-  endfacet
-  facet normal 0.932867 0.360221 -2.03672e-05
-    outer loop
-      vertex -13.8478 5.23463 0.00999928
-      vertex -13.8831 5.32622 3.07752
-      vertex -13.8618 5.27106 3.08991
-    endloop
-  endfacet
-  facet normal 0.933445 0.358722 -0
-    outer loop
-      vertex -13.8478 5.23463 0.00999928
-      vertex -13.8618 5.27106 3.08991
-      vertex -13.8478 5.23463 3.09999
-    endloop
-  endfacet
-  facet normal 0.933096 0.359628 0
-    outer loop
-      vertex -13.8831 5.32622 3.07752
-      vertex -13.8478 5.23463 0.00999928
-      vertex -13.8831 5.32622 0.00999928
-    endloop
-  endfacet
-  facet normal 0.963729 -0.266882 0
-    outer loop
-      vertex -13.9401 6.48596 3.01
-      vertex -13.9139 6.58057 0.00999928
-      vertex -13.9139 6.58057 3.01
-    endloop
-  endfacet
-  facet normal 0.963729 -0.266882 0
-    outer loop
-      vertex -13.9139 6.58057 0.00999928
-      vertex -13.9401 6.48596 3.01
-      vertex -13.9401 6.48596 0.00999928
-    endloop
-  endfacet
-  facet normal 0.615146 -0.788413 0
-    outer loop
-      vertex -13.2688 7.54602 0.00999928
-      vertex -13.1914 7.60641 3.01
-      vertex -13.2688 7.54602 3.01
-    endloop
-  endfacet
-  facet normal 0.615146 -0.788413 0
-    outer loop
-      vertex -13.1914 7.60641 3.01
-      vertex -13.2688 7.54602 0.00999928
-      vertex -13.1914 7.60641 0.00999928
-    endloop
-  endfacet
-  facet normal -0.122356 0.992486 0
-    outer loop
-      vertex -11.804 4.00963 0.00999928
-      vertex -11.7065 4.02165 3.74581
-      vertex -11.7065 4.02165 0.00999928
-    endloop
-  endfacet
-  facet normal -0.122356 0.992486 0
-    outer loop
-      vertex -11.7065 4.02165 3.74581
-      vertex -11.804 4.00963 0.00999928
-      vertex -11.804 4.00963 3.75618
-    endloop
-  endfacet
-  facet normal -0.985248 0.171135 0
-    outer loop
-      vertex -10.0384 5.60982 0.00999928
-      vertex -10.0216 5.70654 3.0144
-      vertex -10.0216 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal -0.985937 0.167119 0.000133127
-    outer loop
-      vertex -10.0216 5.70654 3.0144
-      vertex -10.0384 5.60982 0.00999928
-      vertex -10.0217 5.70595 3.01445
-    endloop
-  endfacet
-  facet normal -0.985243 0.17116 0
-    outer loop
-      vertex -10.0217 5.70595 3.01445
-      vertex -10.0384 5.60982 0.00999928
-      vertex -10.0384 5.60982 3.0263
-    endloop
-  endfacet
-  facet normal -0.817707 -0.575635 0
-    outer loop
-      vertex -10.3371 7.11114 0.00999928
-      vertex -10.3936 7.1914 3.01
-      vertex -10.3936 7.1914 0.00999928
-    endloop
-  endfacet
-  facet normal -0.817707 -0.575635 0
-    outer loop
-      vertex -10.3936 7.1914 3.01
-      vertex -10.3371 7.11114 0.00999928
-      vertex -10.3371 7.11114 3.01
-    endloop
-  endfacet
-  facet normal -0.963729 -0.266882 0
-    outer loop
-      vertex -10.0599 6.48596 0.00999928
-      vertex -10.0861 6.58057 3.01
-      vertex -10.0861 6.58057 0.00999928
-    endloop
-  endfacet
-  facet normal -0.963729 -0.266882 0
-    outer loop
-      vertex -10.0861 6.58057 3.01
-      vertex -10.0599 6.48596 0.00999928
-      vertex -10.0599 6.48596 3.01
-    endloop
-  endfacet
-  facet normal 0.49291 0.87008 -0
-    outer loop
-      vertex -12.9428 4.23616 0.00999928
-      vertex -13.0282 4.28454 3.53992
-      vertex -12.9428 4.23616 3.574
-    endloop
-  endfacet
-  facet normal 0.49291 0.87008 0
-    outer loop
-      vertex -13.0282 4.28454 3.53992
-      vertex -12.9428 4.23616 0.00999928
-      vertex -13.0282 4.28454 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 0.122242 0
-    outer loop
-      vertex -10.0216 5.70654 0.00999928
-      vertex -10.0096 5.80397 3.00722
-      vertex -10.0096 5.80397 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 0.122242 0
-    outer loop
-      vertex -10.0096 5.80397 3.00722
-      vertex -10.0216 5.70654 0.00999928
-      vertex -10.0216 5.70654 3.0144
-    endloop
-  endfacet
-  facet normal 0.999701 -0.02445 0
-    outer loop
-      vertex -14 6 3
-      vertex -13.9976 6.09813 0.00999928
-      vertex -13.9976 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal 0.999701 -0.02445 0
-    outer loop
-      vertex -13.9976 6.09813 0.00999928
-      vertex -14 6 3
-      vertex -14 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0.914131 -0.40542 0
-    outer loop
-      vertex -13.8478 6.76537 3.01
-      vertex -13.808 6.85511 0.00999928
-      vertex -13.808 6.85511 3.01
-    endloop
-  endfacet
-  facet normal 0.914131 -0.40542 0
-    outer loop
-      vertex -13.808 6.85511 0.00999928
-      vertex -13.8478 6.76537 3.01
-      vertex -13.8478 6.76537 0.00999928
-    endloop
-  endfacet
-  facet normal -0.170971 0.985276 0
-    outer loop
-      vertex -11.7065 4.02165 0.00999928
-      vertex -11.6098 4.03843 3.73134
-      vertex -11.6098 4.03843 0.00999928
-    endloop
-  endfacet
-  facet normal -0.170971 0.985276 0
-    outer loop
-      vertex -11.6098 4.03843 3.73134
-      vertex -11.7065 4.02165 0.00999928
-      vertex -11.7065 4.02165 3.74581
-    endloop
-  endfacet
-  facet normal 0.359859 -0.933007 0
-    outer loop
-      vertex -12.7654 7.84776 0.00999928
-      vertex -12.6738 7.88309 3.01
-      vertex -12.7654 7.84776 3.01
-    endloop
-  endfacet
-  facet normal 0.359859 -0.933007 0
-    outer loop
-      vertex -12.6738 7.88309 3.01
-      vertex -12.7654 7.84776 0.00999928
-      vertex -12.6738 7.88309 0.00999928
-    endloop
-  endfacet
-  facet normal -0.933096 -0.359628 0
-    outer loop
-      vertex -10.1169 6.67378 0.00999928
-      vertex -10.1522 6.76537 3.01
-      vertex -10.1522 6.76537 0.00999928
-    endloop
-  endfacet
-  facet normal -0.933096 -0.359628 0
-    outer loop
-      vertex -10.1522 6.76537 3.01
-      vertex -10.1169 6.67378 0.00999928
-      vertex -10.1169 6.67378 3.01
-    endloop
-  endfacet
-  facet normal -0.949505 0.313751 0
-    outer loop
-      vertex -10.1169 5.32622 0.00999928
-      vertex -10.0861 5.41943 3.05683
-      vertex -10.0861 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal -0.946665 0.322219 -0.000287769
-    outer loop
-      vertex -10.0861 5.41943 3.05683
-      vertex -10.1169 5.32622 0.00999928
-      vertex -10.0877 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal -0.949655 0.313297 0
-    outer loop
-      vertex -10.0877 5.41473 3.05764
-      vertex -10.1169 5.32622 0.00999928
-      vertex -10.1169 5.32622 3.07752
-    endloop
-  endfacet
-  facet normal -0.219076 0.975708 0
-    outer loop
-      vertex -11.6098 4.03843 0.00999928
-      vertex -11.514 4.05994 3.71278
-      vertex -11.514 4.05994 0.00999928
-    endloop
-  endfacet
-  facet normal -0.219076 0.975708 0
-    outer loop
-      vertex -11.514 4.05994 3.71278
-      vertex -11.6098 4.03843 0.00999928
-      vertex -11.6098 4.03843 3.73134
-    endloop
-  endfacet
-  facet normal -0.97572 -0.219023 0
-    outer loop
-      vertex -10.0384 6.39018 0.00999928
-      vertex -10.0599 6.48596 3.01
-      vertex -10.0599 6.48596 0.00999928
-    endloop
-  endfacet
-  facet normal -0.97572 -0.219023 0
-    outer loop
-      vertex -10.0599 6.48596 3.01
-      vertex -10.0384 6.39018 0.00999928
-      vertex -10.0384 6.39018 3.01
-    endloop
-  endfacet
-  facet normal -0.985248 -0.171135 0
-    outer loop
-      vertex -10.0216 6.29346 0.00999928
-      vertex -10.0384 6.39018 3.01
-      vertex -10.0384 6.39018 0.00999928
-    endloop
-  endfacet
-  facet normal -0.985248 -0.171135 0
-    outer loop
-      vertex -10.0384 6.39018 3.01
-      vertex -10.0216 6.29346 0.00999928
-      vertex -10.0216 6.29346 3.01
-    endloop
-  endfacet
-  facet normal -0.359859 0.933007 0
-    outer loop
-      vertex -11.3262 4.11691 0.00999928
-      vertex -11.2346 4.15224 3.63772
-      vertex -11.2346 4.15224 0.00999928
-    endloop
-  endfacet
-  facet normal -0.359859 0.933007 0
-    outer loop
-      vertex -11.2346 4.15224 3.63772
-      vertex -11.3262 4.11691 0.00999928
-      vertex -11.3262 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal -0.405401 0.914139 0
-    outer loop
-      vertex -11.2346 4.15224 0.00999928
-      vertex -11.1449 4.19202 3.60667
-      vertex -11.1449 4.19202 0.00999928
-    endloop
-  endfacet
-  facet normal -0.405401 0.914139 0
-    outer loop
-      vertex -11.1449 4.19202 3.60667
-      vertex -11.2346 4.15224 0.00999928
-      vertex -11.2346 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal -0.359859 -0.933007 0
-    outer loop
-      vertex -11.3262 7.88309 0.00999928
-      vertex -11.2346 7.84776 3.01
-      vertex -11.3262 7.88309 3.01
-    endloop
-  endfacet
-  facet normal -0.359859 -0.933007 -0
-    outer loop
-      vertex -11.2346 7.84776 3.01
-      vertex -11.3262 7.88309 0.00999928
-      vertex -11.2346 7.84776 0.00999928
-    endloop
-  endfacet
-  facet normal 0.359859 0.933007 -0
-    outer loop
-      vertex -12.6738 4.11691 0.00999928
-      vertex -12.7654 4.15224 3.63772
-      vertex -12.6738 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal 0.359859 0.933007 0
-    outer loop
-      vertex -12.7654 4.15224 3.63772
-      vertex -12.6738 4.11691 0.00999928
-      vertex -12.7654 4.15224 0.00999928
-    endloop
-  endfacet
-  facet normal 0.49291 -0.87008 0
-    outer loop
-      vertex -13.0282 7.71546 0.00999928
-      vertex -12.9428 7.76384 3.01
-      vertex -13.0282 7.71546 3.01
-    endloop
-  endfacet
-  facet normal 0.49291 -0.87008 0
-    outer loop
-      vertex -12.9428 7.76384 3.01
-      vertex -13.0282 7.71546 0.00999928
-      vertex -12.9428 7.76384 0.00999928
-    endloop
-  endfacet
-  facet normal -0.615209 0.788364 0
-    outer loop
-      vertex -10.8086 4.39358 0.00999928
-      vertex -10.7312 4.45398 3.42917
-      vertex -10.7312 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal -0.615209 0.788364 0
-    outer loop
-      vertex -10.7312 4.45398 3.42917
-      vertex -10.8086 4.39358 0.00999928
-      vertex -10.8086 4.39358 3.46741
-    endloop
-  endfacet
-  facet normal -0.122356 -0.992486 0
-    outer loop
-      vertex -11.804 7.99037 0.00999928
-      vertex -11.7065 7.97835 3.01
-      vertex -11.804 7.99037 3.01
-    endloop
-  endfacet
-  facet normal -0.122356 -0.992486 -0
-    outer loop
-      vertex -11.7065 7.97835 3.01
-      vertex -11.804 7.99037 0.00999928
-      vertex -11.7065 7.97835 0.00999928
-    endloop
-  endfacet
-  facet normal 0.893739 0.448588 5.49163e-05
-    outer loop
-      vertex -13.7638 5.05721 0.00999928
-      vertex -13.808 5.14489 3.12482
-      vertex -13.8001 5.12915 3.12918
-    endloop
-  endfacet
-  facet normal 0.892783 0.450487 -0
-    outer loop
-      vertex -13.7638 5.05721 0.00999928
-      vertex -13.8001 5.12915 3.12918
-      vertex -13.7638 5.05721 3.15294
-    endloop
-  endfacet
-  facet normal 0.892956 0.450144 0
-    outer loop
-      vertex -13.808 5.14489 3.12482
-      vertex -13.7638 5.05721 0.00999928
-      vertex -13.808 5.14489 0.00999928
-    endloop
-  endfacet
-  facet normal 0.9925 0.122242 -0
-    outer loop
-      vertex -13.9784 5.70654 0.00999928
-      vertex -13.9904 5.80397 3.00722
-      vertex -13.9784 5.70654 3.0144
-    endloop
-  endfacet
-  facet normal 0.9925 0.122242 0
-    outer loop
-      vertex -13.9904 5.80397 3.00722
-      vertex -13.9784 5.70654 0.00999928
-      vertex -13.9904 5.80397 0.00999928
-    endloop
-  endfacet
-  facet normal -0.073549 0.997292 0
-    outer loop
-      vertex -11.9019 4.00241 0.00999928
-      vertex -11.804 4.00963 3.75618
-      vertex -11.804 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal -0.073549 0.997292 0
-    outer loop
-      vertex -11.804 4.00963 3.75618
-      vertex -11.9019 4.00241 0.00999928
-      vertex -11.9019 4.00241 3.76241
-    endloop
-  endfacet
-  facet normal 0.788325 -0.615259 0
-    outer loop
-      vertex -13.6064 7.1914 3.01
-      vertex -13.546 7.26879 0.00999928
-      vertex -13.546 7.26879 3.01
-    endloop
-  endfacet
-  facet normal 0.788325 -0.615259 0
-    outer loop
-      vertex -13.546 7.26879 0.00999928
-      vertex -13.6064 7.1914 3.01
-      vertex -13.6064 7.1914 0.00999928
-    endloop
-  endfacet
-  facet normal -0.0245594 0.999698 0
-    outer loop
-      vertex -12 4 0.00999928
-      vertex -11.9019 4.00241 3.76241
-      vertex -11.9019 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal -0.0245594 0.999698 0
-    outer loop
-      vertex -11.9019 4.00241 3.76241
-      vertex -12 4 0.00999928
-      vertex -12 4 3.76449
-    endloop
-  endfacet
-  facet normal -0.892956 -0.450144 0
-    outer loop
-      vertex -10.192 6.85511 0.00999928
-      vertex -10.2362 6.94279 3.01
-      vertex -10.2362 6.94279 0.00999928
-    endloop
-  endfacet
-  facet normal -0.892956 -0.450144 0
-    outer loop
-      vertex -10.2362 6.94279 3.01
-      vertex -10.192 6.85511 0.00999928
-      vertex -10.192 6.85511 3.01
-    endloop
-  endfacet
-  facet normal -0.844491 -0.53557 0
-    outer loop
-      vertex -10.2845 7.0282 0.00999928
-      vertex -10.3371 7.11114 3.01
-      vertex -10.3371 7.11114 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844491 -0.53557 0
-    outer loop
-      vertex -10.3371 7.11114 3.01
-      vertex -10.2845 7.0282 0.00999928
-      vertex -10.2845 7.0282 3.01
-    endloop
-  endfacet
-  facet normal 0.31369 -0.949526 0
-    outer loop
-      vertex -12.6738 7.88309 0.00999928
-      vertex -12.5806 7.91388 3.01
-      vertex -12.6738 7.88309 3.01
-    endloop
-  endfacet
-  facet normal 0.31369 -0.949526 0
-    outer loop
-      vertex -12.5806 7.91388 3.01
-      vertex -12.6738 7.88309 0.00999928
-      vertex -12.5806 7.91388 0.00999928
-    endloop
-  endfacet
-  facet normal 0.788325 0.615259 -0
-    outer loop
-      vertex -13.546 4.73121 0.00999928
-      vertex -13.6064 4.8086 3.24758
-      vertex -13.546 4.73121 3.28188
-    endloop
-  endfacet
-  facet normal 0.788325 0.615259 0
-    outer loop
-      vertex -13.6064 4.8086 3.24758
-      vertex -13.546 4.73121 0.00999928
-      vertex -13.6064 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal -0.615146 -0.788413 0
-    outer loop
-      vertex -10.8086 7.60641 0.00999928
-      vertex -10.7312 7.54602 3.01
-      vertex -10.8086 7.60641 3.01
-    endloop
-  endfacet
-  facet normal -0.615146 -0.788413 -0
-    outer loop
-      vertex -10.7312 7.54602 3.01
-      vertex -10.8086 7.60641 0.00999928
-      vertex -10.7312 7.54602 0.00999928
-    endloop
-  endfacet
-  facet normal 0.914131 0.40542 -0
-    outer loop
-      vertex -13.808 5.14489 0.00999928
-      vertex -13.8478 5.23463 3.09999
-      vertex -13.808 5.14489 3.12482
-    endloop
-  endfacet
-  facet normal 0.914131 0.40542 0
-    outer loop
-      vertex -13.8478 5.23463 3.09999
-      vertex -13.808 5.14489 0.00999928
-      vertex -13.8478 5.23463 0.00999928
-    endloop
-  endfacet
-  facet normal -0.405401 -0.914139 0
-    outer loop
-      vertex -11.2346 7.84776 0.00999928
-      vertex -11.1449 7.80798 3.01
-      vertex -11.2346 7.84776 3.01
-    endloop
-  endfacet
-  facet normal -0.405401 -0.914139 -0
-    outer loop
-      vertex -11.1449 7.80798 3.01
-      vertex -11.2346 7.84776 0.00999928
-      vertex -11.1449 7.80798 0.00999928
-    endloop
-  endfacet
-  facet normal -0.31369 -0.949526 0
-    outer loop
-      vertex -11.4194 7.91388 0.00999928
-      vertex -11.3262 7.88309 3.01
-      vertex -11.4194 7.91388 3.01
-    endloop
-  endfacet
-  facet normal -0.31369 -0.949526 -0
-    outer loop
-      vertex -11.3262 7.88309 3.01
-      vertex -11.4194 7.91388 0.00999928
-      vertex -11.3262 7.88309 0.00999928
-    endloop
-  endfacet
-  facet normal 0.975411 0.220393 -4.57252e-05
-    outer loop
-      vertex -13.9401 5.51404 0.00999928
-      vertex -13.9616 5.60982 3.0263
-      vertex -13.9503 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 0.976056 0.217517 -0
-    outer loop
-      vertex -13.9401 5.51404 0.00999928
-      vertex -13.9503 5.55981 3.03247
-      vertex -13.9401 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal 0.97572 0.219023 0
-    outer loop
-      vertex -13.9616 5.60982 3.0263
-      vertex -13.9401 5.51404 0.00999928
-      vertex -13.9616 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal 0.122356 -0.992486 0
-    outer loop
-      vertex -12.2935 7.97835 0.00999928
-      vertex -12.196 7.99037 3.01
-      vertex -12.2935 7.97835 3.01
-    endloop
-  endfacet
-  facet normal 0.122356 -0.992486 0
-    outer loop
-      vertex -12.196 7.99037 3.01
-      vertex -12.2935 7.97835 0.00999928
-      vertex -12.196 7.99037 0.00999928
-    endloop
-  endfacet
-  facet normal 0.997319 0.0731828 0
-    outer loop
-      vertex -13.994 5.8528 3.00361
-      vertex -13.9976 5.90186 0.00999928
-      vertex -13.9976 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal 0.997293 0.0735256 -0
-    outer loop
-      vertex -13.9904 5.80397 0.00999928
-      vertex -13.994 5.8528 3.00361
-      vertex -13.9904 5.80397 3.00722
-    endloop
-  endfacet
-  facet normal 0.997306 0.0733538 2.8179e-06
-    outer loop
-      vertex -13.994 5.8528 3.00361
-      vertex -13.9904 5.80397 0.00999928
-      vertex -13.9976 5.90186 0.00999928
-    endloop
-  endfacet
-  facet normal 0.073549 -0.997292 0
-    outer loop
-      vertex -12.196 7.99037 0.00999928
-      vertex -12.0981 7.99759 3.01
-      vertex -12.196 7.99037 3.01
-    endloop
-  endfacet
-  facet normal 0.073549 -0.997292 0
-    outer loop
-      vertex -12.0981 7.99759 3.01
-      vertex -12.196 7.99037 0.00999928
-      vertex -12.0981 7.99759 0.00999928
-    endloop
-  endfacet
-  facet normal -0.266719 -0.963774 0
-    outer loop
-      vertex -11.514 7.94006 0.00999928
-      vertex -11.4194 7.91388 3.01
-      vertex -11.514 7.94006 3.01
-    endloop
-  endfacet
-  facet normal -0.266719 -0.963774 -0
-    outer loop
-      vertex -11.4194 7.91388 3.01
-      vertex -11.514 7.94006 0.00999928
-      vertex -11.4194 7.91388 0.00999928
-    endloop
-  endfacet
-  facet normal 0.534922 0.844902 -0
-    outer loop
-      vertex -13.0282 4.28454 0.00999928
-      vertex -13.1052 4.33329 3.50559
-      vertex -13.0282 4.28454 3.53992
-    endloop
-  endfacet
-  facet normal 0.538415 0.84268 0.000107927
-    outer loop
-      vertex -13.0282 4.28454 0.00999928
-      vertex -13.1111 4.33706 3.5032
-      vertex -13.1052 4.33329 3.50559
-    endloop
-  endfacet
-  facet normal 0.535173 0.844742 0
-    outer loop
-      vertex -13.1111 4.33706 3.5032
-      vertex -13.0282 4.28454 0.00999928
-      vertex -13.1111 4.33706 0.00999928
-    endloop
-  endfacet
-  facet normal 0.817707 -0.575635 0
-    outer loop
-      vertex -13.6629 7.11114 3.01
-      vertex -13.6064 7.1914 0.00999928
-      vertex -13.6064 7.1914 3.01
-    endloop
-  endfacet
-  facet normal 0.817707 -0.575635 0
-    outer loop
-      vertex -13.6064 7.1914 0.00999928
-      vertex -13.6629 7.11114 3.01
-      vertex -13.6629 7.11114 0.00999928
-    endloop
-  endfacet
-  facet normal 0.122356 0.992486 -0
-    outer loop
-      vertex -12.196 4.00963 0.00999928
-      vertex -12.2935 4.02165 3.74581
-      vertex -12.196 4.00963 3.75618
-    endloop
-  endfacet
-  facet normal 0.122356 0.992486 0
-    outer loop
-      vertex -12.2935 4.02165 3.74581
-      vertex -12.196 4.00963 0.00999928
-      vertex -12.2935 4.02165 0.00999928
-    endloop
-  endfacet
-  facet normal 0.963729 0.266882 -0
-    outer loop
-      vertex -13.9139 5.41943 0.00999928
-      vertex -13.9401 5.51404 3.04041
-      vertex -13.9139 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0.963729 0.266882 0
-    outer loop
-      vertex -13.9401 5.51404 3.04041
-      vertex -13.9139 5.41943 0.00999928
-      vertex -13.9401 5.51404 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724162 0.68963 0
-    outer loop
-      vertex -10.5858 4.58579 0.00999928
-      vertex -10.5181 4.65688 3.31846
-      vertex -10.5181 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724066 0.68973 -4.12488e-06
-    outer loop
-      vertex -10.5181 4.65688 3.31846
-      vertex -10.5858 4.58579 0.00999928
-      vertex -10.5858 4.58581 3.35424
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -10.5858 4.58581 3.35424
-      vertex -10.5858 4.58579 0.00999928
-      vertex -10.5858 4.58579 3.35425
-    endloop
-  endfacet
-  facet normal 0.405401 0.914139 -0
-    outer loop
-      vertex -12.7654 4.15224 0.00999928
-      vertex -12.8551 4.19202 3.60667
-      vertex -12.7654 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 0.405401 0.914139 0
-    outer loop
-      vertex -12.8551 4.19202 3.60667
-      vertex -12.7654 4.15224 0.00999928
-      vertex -12.8551 4.19202 0.00999928
-    endloop
-  endfacet
-  facet normal -0.689525 -0.724261 0
-    outer loop
-      vertex -10.6569 7.4819 0.00999928
-      vertex -10.5858 7.41421 3.01
-      vertex -10.6569 7.4819 3.01
-    endloop
-  endfacet
-  facet normal -0.689525 -0.724261 -0
-    outer loop
-      vertex -10.5858 7.41421 3.01
-      vertex -10.6569 7.4819 0.00999928
-      vertex -10.5858 7.41421 0.00999928
-    endloop
-  endfacet
-  facet normal -0.870479 0.492205 0
-    outer loop
-      vertex -10.2845 4.97179 0.00999928
-      vertex -10.2362 5.05721 3.15294
-      vertex -10.2362 5.05721 0.00999928
-    endloop
-  endfacet
-  facet normal -0.870382 0.492377 -6.16218e-06
-    outer loop
-      vertex -10.2362 5.05721 3.15294
-      vertex -10.2845 4.97179 0.00999928
-      vertex -10.2746 4.98933 3.17537
-    endloop
-  endfacet
-  facet normal -0.870859 0.491534 0
-    outer loop
-      vertex -10.2746 4.98933 3.17537
-      vertex -10.2845 4.97179 0.00999928
-      vertex -10.2845 4.97179 3.18213
-    endloop
-  endfacet
-  facet normal 0.997293 -0.0735256 0
-    outer loop
-      vertex -13.994 6.1472 3.00361
-      vertex -13.9904 6.19603 0.00999928
-      vertex -13.9904 6.19603 3.00722
-    endloop
-  endfacet
-  facet normal 0.99732 -0.0731681 5.86359e-06
-    outer loop
-      vertex -13.9976 6.09813 3.00241
-      vertex -13.9904 6.19603 0.00999928
-      vertex -13.994 6.1472 3.00361
-    endloop
-  endfacet
-  facet normal 0.997307 -0.0733463 0
-    outer loop
-      vertex -13.9904 6.19603 0.00999928
-      vertex -13.9976 6.09813 3.00241
-      vertex -13.9976 6.09813 0.00999928
-    endloop
-  endfacet
-  facet normal -0.892956 0.450144 0
-    outer loop
-      vertex -10.2362 5.05721 0.00999928
-      vertex -10.192 5.14489 3.12482
-      vertex -10.192 5.14489 0.00999928
-    endloop
-  endfacet
-  facet normal -0.893739 0.448588 5.49163e-05
-    outer loop
-      vertex -10.192 5.14489 3.12482
-      vertex -10.2362 5.05721 0.00999928
-      vertex -10.1999 5.12915 3.12918
-    endloop
-  endfacet
-  facet normal -0.892783 0.450487 0
-    outer loop
-      vertex -10.1999 5.12915 3.12918
-      vertex -10.2362 5.05721 0.00999928
-      vertex -10.2362 5.05721 3.15294
-    endloop
-  endfacet
-  facet normal 0.689525 0.724261 -0
-    outer loop
-      vertex -13.3431 4.5181 0.00999928
-      vertex -13.4142 4.58579 3.35425
-      vertex -13.3431 4.5181 3.39259
-    endloop
-  endfacet
-  facet normal 0.689525 0.724261 0
-    outer loop
-      vertex -13.4142 4.58579 3.35425
-      vertex -13.3431 4.5181 0.00999928
-      vertex -13.4142 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449575 0.893243 0
-    outer loop
-      vertex -11.1449 4.19202 0.00999928
-      vertex -11.0572 4.23616 3.574
-      vertex -11.0572 4.23616 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449686 0.893187 3.40941e-06
-    outer loop
-      vertex -11.0572 4.23616 3.574
-      vertex -11.1449 4.19202 0.00999928
-      vertex -11.1034 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal -0.449451 0.893305 0
-    outer loop
-      vertex -11.1034 4.2129 3.59038
-      vertex -11.1449 4.19202 0.00999928
-      vertex -11.1449 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal 0.933096 -0.359628 0
-    outer loop
-      vertex -13.8831 6.67378 3.01
-      vertex -13.8478 6.76537 0.00999928
-      vertex -13.8478 6.76537 3.01
-    endloop
-  endfacet
-  facet normal 0.933096 -0.359628 0
-    outer loop
-      vertex -13.8478 6.76537 0.00999928
-      vertex -13.8831 6.67378 3.01
-      vertex -13.8831 6.67378 0.00999928
-    endloop
-  endfacet
-  facet normal 0.535173 -0.844742 0
-    outer loop
-      vertex -13.1111 7.66294 0.00999928
-      vertex -13.0282 7.71546 3.01
-      vertex -13.1111 7.66294 3.01
-    endloop
-  endfacet
-  facet normal 0.535173 -0.844742 0
-    outer loop
-      vertex -13.0282 7.71546 3.01
-      vertex -13.1111 7.66294 0.00999928
-      vertex -13.0282 7.71546 0.00999928
-    endloop
-  endfacet
-  facet normal 0.449575 -0.893243 0
-    outer loop
-      vertex -12.9428 7.76384 0.00999928
-      vertex -12.8551 7.80798 3.01
-      vertex -12.9428 7.76384 3.01
-    endloop
-  endfacet
-  facet normal 0.449575 -0.893243 0
-    outer loop
-      vertex -12.8551 7.80798 3.01
-      vertex -12.9428 7.76384 0.00999928
-      vertex -12.8551 7.80798 0.00999928
-    endloop
-  endfacet
-  facet normal -0.914131 0.40542 0
-    outer loop
-      vertex -10.192 5.14489 0.00999928
-      vertex -10.1522 5.23463 3.09999
-      vertex -10.1522 5.23463 0.00999928
-    endloop
-  endfacet
-  facet normal -0.914131 0.40542 0
-    outer loop
-      vertex -10.1522 5.23463 3.09999
-      vertex -10.192 5.14489 0.00999928
-      vertex -10.192 5.14489 3.12482
-    endloop
-  endfacet
-  facet normal 0.724162 -0.68963 0
-    outer loop
-      vertex -13.4819 7.34312 3.01
-      vertex -13.4142 7.41421 0.00999928
-      vertex -13.4142 7.41421 3.01
-    endloop
-  endfacet
-  facet normal 0.724162 -0.68963 0
-    outer loop
-      vertex -13.4142 7.41421 0.00999928
-      vertex -13.4819 7.34312 3.01
-      vertex -13.4819 7.34312 0.00999928
-    endloop
-  endfacet
-  facet normal -0.0245594 -0.999698 0
-    outer loop
-      vertex -12 8 0.00999928
-      vertex -11.9019 7.99759 3.01
-      vertex -12 8 3.01
-    endloop
-  endfacet
-  facet normal -0.0245594 -0.999698 -0
-    outer loop
-      vertex -11.9019 7.99759 3.01
-      vertex -12 8 0.00999928
-      vertex -11.9019 7.99759 0.00999928
-    endloop
-  endfacet
-  facet normal -0.49291 -0.87008 0
-    outer loop
-      vertex -11.0572 7.76384 0.00999928
-      vertex -10.9718 7.71546 3.01
-      vertex -11.0572 7.76384 3.01
-    endloop
-  endfacet
-  facet normal -0.49291 -0.87008 -0
-    outer loop
-      vertex -10.9718 7.71546 3.01
-      vertex -11.0572 7.76384 0.00999928
-      vertex -10.9718 7.71546 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449575 -0.893243 0
-    outer loop
-      vertex -11.1449 7.80798 0.00999928
-      vertex -11.0572 7.76384 3.01
-      vertex -11.1449 7.80798 3.01
-    endloop
-  endfacet
-  facet normal -0.449575 -0.893243 -0
-    outer loop
-      vertex -11.0572 7.76384 3.01
-      vertex -11.1449 7.80798 0.00999928
-      vertex -11.0572 7.76384 0.00999928
-    endloop
-  endfacet
-  facet normal 0.615209 0.788364 -0
-    outer loop
-      vertex -13.1914 4.39358 0.00999928
-      vertex -13.2688 4.45398 3.42917
-      vertex -13.1914 4.39358 3.46741
-    endloop
-  endfacet
-  facet normal 0.615209 0.788364 0
-    outer loop
-      vertex -13.2688 4.45398 3.42917
-      vertex -13.1914 4.39358 0.00999928
-      vertex -13.2688 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal -0.266719 0.963774 0
-    outer loop
-      vertex -11.514 4.05994 0.00999928
-      vertex -11.4194 4.08612 3.6902
-      vertex -11.4194 4.08612 0.00999928
-    endloop
-  endfacet
-  facet normal -0.266719 0.963774 0
-    outer loop
-      vertex -11.4194 4.08612 3.6902
-      vertex -11.514 4.05994 0.00999928
-      vertex -11.514 4.05994 3.71278
-    endloop
-  endfacet
-  facet normal 0.219076 -0.975708 0
-    outer loop
-      vertex -12.486 7.94006 0.00999928
-      vertex -12.3902 7.96157 3.01
-      vertex -12.486 7.94006 3.01
-    endloop
-  endfacet
-  facet normal 0.219076 -0.975708 0
-    outer loop
-      vertex -12.3902 7.96157 3.01
-      vertex -12.486 7.94006 0.00999928
-      vertex -12.3902 7.96157 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 0.615259 0
-    outer loop
-      vertex -10.454 4.73121 0.00999928
-      vertex -10.3936 4.8086 3.24758
-      vertex -10.3936 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 0.615259 0
-    outer loop
-      vertex -10.3936 4.8086 3.24758
-      vertex -10.454 4.73121 0.00999928
-      vertex -10.454 4.73121 3.28188
-    endloop
-  endfacet
-  facet normal 0.266719 -0.963774 0
-    outer loop
-      vertex -12.5806 7.91388 0.00999928
-      vertex -12.486 7.94006 3.01
-      vertex -12.5806 7.91388 3.01
-    endloop
-  endfacet
-  facet normal 0.266719 -0.963774 0
-    outer loop
-      vertex -12.486 7.94006 3.01
-      vertex -12.5806 7.91388 0.00999928
-      vertex -12.486 7.94006 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653339 0.757066 0
-    outer loop
-      vertex -10.7312 4.45398 0.00999928
-      vertex -10.6569 4.5181 3.39259
-      vertex -10.6569 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653344 0.757061 1.9929e-07
-    outer loop
-      vertex -10.6569 4.5181 3.39259
-      vertex -10.7312 4.45398 0.00999928
-      vertex -10.7269 4.45769 3.42681
-    endloop
-  endfacet
-  facet normal -0.653253 0.75714 0
-    outer loop
-      vertex -10.7269 4.45769 3.42681
-      vertex -10.7312 4.45398 0.00999928
-      vertex -10.7312 4.45398 3.42917
-    endloop
-  endfacet
-  facet normal -0.844461 0.535616 0
-    outer loop
-      vertex -10.3371 4.88886 0.00999928
-      vertex -10.2845 4.97179 3.18213
-      vertex -10.2845 4.97179 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844461 0.535616 0
-    outer loop
-      vertex -10.2845 4.97179 3.18213
-      vertex -10.3371 4.88886 0.00999928
-      vertex -10.3371 4.88886 3.21412
-    endloop
-  endfacet
-  facet normal -0.535173 0.844742 0
-    outer loop
-      vertex -10.9718 4.28454 0.00999928
-      vertex -10.8889 4.33706 3.5032
-      vertex -10.8889 4.33706 0.00999928
-    endloop
-  endfacet
-  facet normal -0.538415 0.84268 0.000107927
-    outer loop
-      vertex -10.8889 4.33706 3.5032
-      vertex -10.9718 4.28454 0.00999928
-      vertex -10.8948 4.33329 3.50559
-    endloop
-  endfacet
-  facet normal -0.534922 0.844902 0
-    outer loop
-      vertex -10.8948 4.33329 3.50559
-      vertex -10.9718 4.28454 0.00999928
-      vertex -10.9718 4.28454 3.53992
-    endloop
-  endfacet
-  facet normal 0.97572 -0.219023 0
-    outer loop
-      vertex -13.9616 6.39018 3.01
-      vertex -13.9401 6.48596 0.00999928
-      vertex -13.9401 6.48596 3.01
-    endloop
-  endfacet
-  facet normal 0.97572 -0.219023 0
-    outer loop
-      vertex -13.9401 6.48596 0.00999928
-      vertex -13.9616 6.39018 3.01
-      vertex -13.9616 6.39018 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 -0.653071 0
-    outer loop
-      vertex -10.454 7.26879 0.00999928
-      vertex -10.5181 7.34312 3.01
-      vertex -10.5181 7.34312 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 -0.653071 0
-    outer loop
-      vertex -10.5181 7.34312 3.01
-      vertex -10.454 7.26879 0.00999928
-      vertex -10.454 7.26879 3.01
-    endloop
-  endfacet
-  facet normal 0.892956 -0.450144 0
-    outer loop
-      vertex -13.808 6.85511 3.01
-      vertex -13.7638 6.94279 0.00999928
-      vertex -13.7638 6.94279 3.01
-    endloop
-  endfacet
-  facet normal 0.892956 -0.450144 0
-    outer loop
-      vertex -13.7638 6.94279 0.00999928
-      vertex -13.808 6.85511 3.01
-      vertex -13.808 6.85511 0.00999928
-    endloop
-  endfacet
-  facet normal 0.449451 0.893305 -0
-    outer loop
-      vertex -12.8551 4.19202 0.00999928
-      vertex -12.8966 4.2129 3.59038
-      vertex -12.8551 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal 0.449686 0.893187 3.40941e-06
-    outer loop
-      vertex -12.8551 4.19202 0.00999928
-      vertex -12.9428 4.23616 3.574
-      vertex -12.8966 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 0.449575 0.893243 0
-    outer loop
-      vertex -12.9428 4.23616 3.574
-      vertex -12.8551 4.19202 0.00999928
-      vertex -12.9428 4.23616 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 -0.615259 0
-    outer loop
-      vertex -10.3936 7.1914 0.00999928
-      vertex -10.454 7.26879 3.01
-      vertex -10.454 7.26879 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 -0.615259 0
-    outer loop
-      vertex -10.454 7.26879 3.01
-      vertex -10.3936 7.1914 0.00999928
-      vertex -10.3936 7.1914 3.01
-    endloop
-  endfacet
-  facet normal 0.870382 0.492377 -6.16218e-06
-    outer loop
-      vertex -13.7155 4.97179 0.00999928
-      vertex -13.7638 5.05721 3.15294
-      vertex -13.7254 4.98933 3.17537
-    endloop
-  endfacet
-  facet normal 0.870859 0.491534 -0
-    outer loop
-      vertex -13.7155 4.97179 0.00999928
-      vertex -13.7254 4.98933 3.17537
-      vertex -13.7155 4.97179 3.18213
-    endloop
-  endfacet
-  facet normal 0.870479 0.492205 0
-    outer loop
-      vertex -13.7638 5.05721 3.15294
-      vertex -13.7155 4.97179 0.00999928
-      vertex -13.7638 5.05721 0.00999928
-    endloop
-  endfacet
-  facet normal -0.219076 -0.975708 0
-    outer loop
-      vertex -11.6098 7.96157 0.00999928
-      vertex -11.514 7.94006 3.01
-      vertex -11.6098 7.96157 3.01
-    endloop
-  endfacet
-  facet normal -0.219076 -0.975708 -0
-    outer loop
-      vertex -11.514 7.94006 3.01
-      vertex -11.6098 7.96157 0.00999928
-      vertex -11.514 7.94006 0.00999928
-    endloop
-  endfacet
-  facet normal 0.405401 -0.914139 0
-    outer loop
-      vertex -12.8551 7.80798 0.00999928
-      vertex -12.7654 7.84776 3.01
-      vertex -12.8551 7.80798 3.01
-    endloop
-  endfacet
-  facet normal 0.405401 -0.914139 0
-    outer loop
-      vertex -12.7654 7.84776 3.01
-      vertex -12.8551 7.80798 0.00999928
-      vertex -12.7654 7.84776 0.00999928
-    endloop
-  endfacet
-  facet normal 0.219076 0.975708 -0
-    outer loop
-      vertex -12.3902 4.03843 0.00999928
-      vertex -12.486 4.05994 3.71278
-      vertex -12.3902 4.03843 3.73134
-    endloop
-  endfacet
-  facet normal 0.219076 0.975708 0
-    outer loop
-      vertex -12.486 4.05994 3.71278
-      vertex -12.3902 4.03843 0.00999928
-      vertex -12.486 4.05994 0.00999928
-    endloop
-  endfacet
-  facet normal 0.266719 0.963774 -0
-    outer loop
-      vertex -12.486 4.05994 0.00999928
-      vertex -12.5806 4.08612 3.6902
-      vertex -12.486 4.05994 3.71278
-    endloop
-  endfacet
-  facet normal 0.266719 0.963774 0
-    outer loop
-      vertex -12.5806 4.08612 3.6902
-      vertex -12.486 4.05994 0.00999928
-      vertex -12.5806 4.08612 0.00999928
-    endloop
-  endfacet
-  facet normal 0.575579 0.817746 -0
-    outer loop
-      vertex -13.1111 4.33706 0.00999928
-      vertex -13.1914 4.39358 3.46741
-      vertex -13.1111 4.33706 3.5032
-    endloop
-  endfacet
-  facet normal 0.575579 0.817746 0
-    outer loop
-      vertex -13.1914 4.39358 3.46741
-      vertex -13.1111 4.33706 0.00999928
-      vertex -13.1914 4.39358 0.00999928
-    endloop
-  endfacet
-  facet normal 0.575579 0.817746 -0
-    outer loop
-      vertex 10.8889 4.33706 0.00999928
-      vertex 10.8086 4.39358 3.46741
-      vertex 10.8889 4.33706 3.5032
-    endloop
-  endfacet
-  facet normal 0.575579 0.817746 0
-    outer loop
-      vertex 10.8086 4.39358 3.46741
-      vertex 10.8889 4.33706 0.00999928
-      vertex 10.8086 4.39358 0.00999928
-    endloop
-  endfacet
-  facet normal -0.122356 -0.992486 0
-    outer loop
-      vertex 12.196 7.99037 0.00999928
-      vertex 12.2935 7.97835 3.01
-      vertex 12.196 7.99037 3.01
-    endloop
-  endfacet
-  facet normal -0.122356 -0.992486 -0
-    outer loop
-      vertex 12.2935 7.97835 3.01
-      vertex 12.196 7.99037 0.00999928
-      vertex 12.2935 7.97835 0.00999928
-    endloop
-  endfacet
-  facet normal -0.997293 -0.0735256 0
-    outer loop
-      vertex 13.9904 6.19603 0.00999928
-      vertex 13.994 6.1472 3.00361
-      vertex 13.9904 6.19603 3.00722
-    endloop
-  endfacet
-  facet normal -0.997307 -0.0733463 2.94012e-06
-    outer loop
-      vertex 13.9976 6.09813 0.00999928
-      vertex 13.994 6.1472 3.00361
-      vertex 13.9904 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal -0.99732 -0.0731679 0
-    outer loop
-      vertex 13.994 6.1472 3.00361
-      vertex 13.9976 6.09813 0.00999928
-      vertex 13.9976 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal -0.219076 0.975708 0
-    outer loop
-      vertex 12.3902 4.03843 0.00999928
-      vertex 12.486 4.05994 3.71278
-      vertex 12.486 4.05994 0.00999928
-    endloop
-  endfacet
-  facet normal -0.219076 0.975708 0
-    outer loop
-      vertex 12.486 4.05994 3.71278
-      vertex 12.3902 4.03843 0.00999928
-      vertex 12.3902 4.03843 3.73134
-    endloop
-  endfacet
-  facet normal 0.949505 -0.313751 0
-    outer loop
-      vertex 10.0861 6.58057 3.01
-      vertex 10.1169 6.67378 0.00999928
-      vertex 10.1169 6.67378 3.01
-    endloop
-  endfacet
-  facet normal 0.949505 -0.313751 0
-    outer loop
-      vertex 10.1169 6.67378 0.00999928
-      vertex 10.0861 6.58057 3.01
-      vertex 10.0861 6.58057 0.00999928
-    endloop
-  endfacet
-  facet normal 0.844461 0.535616 -0
-    outer loop
-      vertex 10.3371 4.88886 0.00999928
-      vertex 10.2845 4.97179 3.18213
-      vertex 10.3371 4.88886 3.21412
-    endloop
-  endfacet
-  facet normal 0.844461 0.535616 0
-    outer loop
-      vertex 10.2845 4.97179 3.18213
-      vertex 10.3371 4.88886 0.00999928
-      vertex 10.2845 4.97179 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 -0.653071 0
-    outer loop
-      vertex 13.546 7.26879 0.00999928
-      vertex 13.4819 7.34312 3.01
-      vertex 13.4819 7.34312 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 -0.653071 0
-    outer loop
-      vertex 13.4819 7.34312 3.01
-      vertex 13.546 7.26879 0.00999928
-      vertex 13.546 7.26879 3.01
-    endloop
-  endfacet
-  facet normal 0.219076 0.975708 -0
-    outer loop
-      vertex 11.6098 4.03843 0.00999928
-      vertex 11.514 4.05994 3.71278
-      vertex 11.6098 4.03843 3.73134
-    endloop
-  endfacet
-  facet normal 0.219076 0.975708 0
-    outer loop
-      vertex 11.514 4.05994 3.71278
-      vertex 11.6098 4.03843 0.00999928
-      vertex 11.514 4.05994 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653339 0.757066 0
-    outer loop
-      vertex 13.2688 4.45398 0.00999928
-      vertex 13.3431 4.5181 3.39259
-      vertex 13.3431 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653344 0.757061 1.9929e-07
-    outer loop
-      vertex 13.3431 4.5181 3.39259
-      vertex 13.2688 4.45398 0.00999928
-      vertex 13.2731 4.45769 3.42681
-    endloop
-  endfacet
-  facet normal -0.653253 0.75714 0
-    outer loop
-      vertex 13.2731 4.45769 3.42681
-      vertex 13.2688 4.45398 0.00999928
-      vertex 13.2688 4.45398 3.42917
-    endloop
-  endfacet
-  facet normal -0.31369 0.949526 0
-    outer loop
-      vertex 12.5806 4.08612 0.00999928
-      vertex 12.6738 4.11691 3.66529
-      vertex 12.6738 4.11691 0.00999928
-    endloop
-  endfacet
-  facet normal -0.313743 0.949508 1.51104e-06
-    outer loop
-      vertex 12.6738 4.11691 3.66529
-      vertex 12.5806 4.08612 0.00999928
-      vertex 12.613 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal -0.313589 0.949559 0
-    outer loop
-      vertex 12.613 4.09682 3.68097
-      vertex 12.5806 4.08612 0.00999928
-      vertex 12.5806 4.08612 3.6902
-    endloop
-  endfacet
-  facet normal -0.405401 0.914139 0
-    outer loop
-      vertex 12.7654 4.15224 0.00999928
-      vertex 12.8551 4.19202 3.60667
-      vertex 12.8551 4.19202 0.00999928
-    endloop
-  endfacet
-  facet normal -0.405401 0.914139 0
-    outer loop
-      vertex 12.8551 4.19202 3.60667
-      vertex 12.7654 4.15224 0.00999928
-      vertex 12.7654 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 0.49291 0.87008 -0
-    outer loop
-      vertex 11.0572 4.23616 0.00999928
-      vertex 10.9718 4.28454 3.53992
-      vertex 11.0572 4.23616 3.574
-    endloop
-  endfacet
-  facet normal 0.49291 0.87008 0
-    outer loop
-      vertex 10.9718 4.28454 3.53992
-      vertex 11.0572 4.23616 0.00999928
-      vertex 10.9718 4.28454 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844491 -0.53557 0
-    outer loop
-      vertex 13.7155 7.0282 0.00999928
-      vertex 13.6629 7.11114 3.01
-      vertex 13.6629 7.11114 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844491 -0.53557 0
-    outer loop
-      vertex 13.6629 7.11114 3.01
-      vertex 13.7155 7.0282 0.00999928
-      vertex 13.7155 7.0282 3.01
-    endloop
-  endfacet
-  facet normal 0.932867 0.360221 -2.03672e-05
-    outer loop
-      vertex 10.1522 5.23463 0.00999928
-      vertex 10.1169 5.32622 3.07752
-      vertex 10.1382 5.27106 3.08991
-    endloop
-  endfacet
-  facet normal 0.933445 0.358722 -0
-    outer loop
-      vertex 10.1522 5.23463 0.00999928
-      vertex 10.1382 5.27106 3.08991
-      vertex 10.1522 5.23463 3.09999
-    endloop
-  endfacet
-  facet normal 0.933096 0.359628 0
-    outer loop
-      vertex 10.1169 5.32622 3.07752
-      vertex 10.1522 5.23463 0.00999928
-      vertex 10.1169 5.32622 0.00999928
-    endloop
-  endfacet
-  facet normal 0.073549 -0.997292 0
-    outer loop
-      vertex 11.804 7.99037 0.00999928
-      vertex 11.9019 7.99759 3.01
-      vertex 11.804 7.99037 3.01
-    endloop
-  endfacet
-  facet normal 0.073549 -0.997292 0
-    outer loop
-      vertex 11.9019 7.99759 3.01
-      vertex 11.804 7.99037 0.00999928
-      vertex 11.9019 7.99759 0.00999928
-    endloop
-  endfacet
-  facet normal -0.615209 0.788364 0
-    outer loop
-      vertex 13.1914 4.39358 0.00999928
-      vertex 13.2688 4.45398 3.42917
-      vertex 13.2688 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal -0.615209 0.788364 0
-    outer loop
-      vertex 13.2688 4.45398 3.42917
-      vertex 13.1914 4.39358 0.00999928
-      vertex 13.1914 4.39358 3.46741
-    endloop
-  endfacet
-  facet normal -0.535173 0.844742 0
-    outer loop
-      vertex 13.0282 4.28454 0.00999928
-      vertex 13.1111 4.33706 3.5032
-      vertex 13.1111 4.33706 0.00999928
-    endloop
-  endfacet
-  facet normal -0.538415 0.84268 0.000107927
-    outer loop
-      vertex 13.1111 4.33706 3.5032
-      vertex 13.0282 4.28454 0.00999928
-      vertex 13.1052 4.33329 3.50559
-    endloop
-  endfacet
-  facet normal -0.534922 0.844902 0
-    outer loop
-      vertex 13.1052 4.33329 3.50559
-      vertex 13.0282 4.28454 0.00999928
-      vertex 13.0282 4.28454 3.53992
-    endloop
-  endfacet
-  facet normal 0.266719 0.963774 -0
-    outer loop
-      vertex 11.514 4.05994 0.00999928
-      vertex 11.4194 4.08612 3.6902
-      vertex 11.514 4.05994 3.71278
-    endloop
-  endfacet
-  facet normal 0.266719 0.963774 0
-    outer loop
-      vertex 11.4194 4.08612 3.6902
-      vertex 11.514 4.05994 0.00999928
-      vertex 11.4194 4.08612 0.00999928
-    endloop
-  endfacet
-  facet normal 0.575647 -0.817698 0
-    outer loop
-      vertex 10.8086 7.60641 0.00999928
-      vertex 10.8889 7.66294 3.01
-      vertex 10.8086 7.60641 3.01
-    endloop
-  endfacet
-  facet normal 0.575647 -0.817698 0
-    outer loop
-      vertex 10.8889 7.66294 3.01
-      vertex 10.8086 7.60641 0.00999928
-      vertex 10.8889 7.66294 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 -0.122242 0
-    outer loop
-      vertex 13.9904 6.19603 3.00722
-      vertex 13.9784 6.29346 3.01
-      vertex 13.9784 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 -0.122242 -0
-    outer loop
-      vertex 13.9904 6.19603 3.00722
-      vertex 13.9784 6.29346 0.00999928
-      vertex 13.9904 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal -0.992172 -0.121362 -0.0294284
-    outer loop
-      vertex 13.9784 6.29346 3.01
-      vertex 13.9904 6.19603 3.00722
-      vertex 13.9857 6.23378 3.01
-    endloop
-  endfacet
-  facet normal 0.359859 -0.933007 0
-    outer loop
-      vertex 11.2346 7.84776 0.00999928
-      vertex 11.3262 7.88309 3.01
-      vertex 11.2346 7.84776 3.01
-    endloop
-  endfacet
-  facet normal 0.359859 -0.933007 0
-    outer loop
-      vertex 11.3262 7.88309 3.01
-      vertex 11.2346 7.84776 0.00999928
-      vertex 11.3262 7.88309 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449575 -0.893243 0
-    outer loop
-      vertex 12.8551 7.80798 0.00999928
-      vertex 12.9428 7.76384 3.01
-      vertex 12.8551 7.80798 3.01
-    endloop
-  endfacet
-  facet normal -0.449575 -0.893243 -0
-    outer loop
-      vertex 12.9428 7.76384 3.01
-      vertex 12.8551 7.80798 0.00999928
-      vertex 12.9428 7.76384 0.00999928
-    endloop
-  endfacet
-  facet normal 0.49291 -0.87008 0
-    outer loop
-      vertex 10.9718 7.71546 0.00999928
-      vertex 11.0572 7.76384 3.01
-      vertex 10.9718 7.71546 3.01
-    endloop
-  endfacet
-  facet normal 0.49291 -0.87008 0
-    outer loop
-      vertex 11.0572 7.76384 3.01
-      vertex 10.9718 7.71546 0.00999928
-      vertex 11.0572 7.76384 0.00999928
-    endloop
-  endfacet
-  facet normal -0.405401 -0.914139 0
-    outer loop
-      vertex 12.7654 7.84776 0.00999928
-      vertex 12.8551 7.80798 3.01
-      vertex 12.7654 7.84776 3.01
-    endloop
-  endfacet
-  facet normal -0.405401 -0.914139 -0
-    outer loop
-      vertex 12.8551 7.80798 3.01
-      vertex 12.7654 7.84776 0.00999928
-      vertex 12.8551 7.80798 0.00999928
-    endloop
-  endfacet
-  facet normal 0.817534 0.575881 -9.2087e-06
-    outer loop
-      vertex 10.3936 4.8086 0.00999928
-      vertex 10.3371 4.88886 3.21412
-      vertex 10.3631 4.85195 3.22836
-    endloop
-  endfacet
-  facet normal 0.817856 0.575423 -0
-    outer loop
-      vertex 10.3936 4.8086 0.00999928
-      vertex 10.3631 4.85195 3.22836
-      vertex 10.3936 4.8086 3.24758
-    endloop
-  endfacet
-  facet normal 0.817707 0.575635 0
-    outer loop
-      vertex 10.3371 4.88886 3.21412
-      vertex 10.3936 4.8086 0.00999928
-      vertex 10.3371 4.88886 0.00999928
-    endloop
-  endfacet
-  facet normal -0.073549 0.997292 0
-    outer loop
-      vertex 12.0981 4.00241 0.00999928
-      vertex 12.196 4.00963 3.75618
-      vertex 12.196 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal -0.073549 0.997292 0
-    outer loop
-      vertex 12.196 4.00963 3.75618
-      vertex 12.0981 4.00241 0.00999928
-      vertex 12.0981 4.00241 3.76241
-    endloop
-  endfacet
-  facet normal 0.893739 0.448588 5.49163e-05
-    outer loop
-      vertex 10.2362 5.05721 0.00999928
-      vertex 10.192 5.14489 3.12482
-      vertex 10.1999 5.12915 3.12918
-    endloop
-  endfacet
-  facet normal 0.892783 0.450487 -0
-    outer loop
-      vertex 10.2362 5.05721 0.00999928
-      vertex 10.1999 5.12915 3.12918
-      vertex 10.2362 5.05721 3.15294
-    endloop
-  endfacet
-  facet normal 0.892956 0.450144 0
-    outer loop
-      vertex 10.192 5.14489 3.12482
-      vertex 10.2362 5.05721 0.00999928
-      vertex 10.192 5.14489 0.00999928
-    endloop
-  endfacet
-  facet normal -0.073549 -0.997292 0
-    outer loop
-      vertex 12.0981 7.99759 0.00999928
-      vertex 12.196 7.99037 3.01
-      vertex 12.0981 7.99759 3.01
-    endloop
-  endfacet
-  facet normal -0.073549 -0.997292 -0
-    outer loop
-      vertex 12.196 7.99037 3.01
-      vertex 12.0981 7.99759 0.00999928
-      vertex 12.196 7.99037 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844461 0.535616 0
-    outer loop
-      vertex 13.6629 4.88886 0.00999928
-      vertex 13.7155 4.97179 3.18213
-      vertex 13.7155 4.97179 0.00999928
-    endloop
-  endfacet
-  facet normal -0.844461 0.535616 0
-    outer loop
-      vertex 13.7155 4.97179 3.18213
-      vertex 13.6629 4.88886 0.00999928
-      vertex 13.6629 4.88886 3.21412
-    endloop
-  endfacet
-  facet normal -0.615146 -0.788413 0
-    outer loop
-      vertex 13.1914 7.60641 0.00999928
-      vertex 13.2688 7.54602 3.01
-      vertex 13.1914 7.60641 3.01
-    endloop
-  endfacet
-  facet normal -0.615146 -0.788413 -0
-    outer loop
-      vertex 13.2688 7.54602 3.01
-      vertex 13.1914 7.60641 0.00999928
-      vertex 13.2688 7.54602 0.00999928
-    endloop
-  endfacet
-  facet normal 0.985248 -0.171135 0
-    outer loop
-      vertex 10.0216 6.29346 3.01
-      vertex 10.0384 6.39018 0.00999928
-      vertex 10.0384 6.39018 3.01
-    endloop
-  endfacet
-  facet normal 0.985248 -0.171135 0
-    outer loop
-      vertex 10.0384 6.39018 0.00999928
-      vertex 10.0216 6.29346 3.01
-      vertex 10.0216 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 -0.02445 -0
-    outer loop
-      vertex 14 6 3
-      vertex 13.9976 6.09813 0.00999928
-      vertex 14 6 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 -0.02445 0
-    outer loop
-      vertex 13.9976 6.09813 0.00999928
-      vertex 14 6 3
-      vertex 13.9976 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244476 0
-    outer loop
-      vertex 13.9976 5.90186 0.00999928
-      vertex 14 6 3
-      vertex 14 6 0.00999928
-    endloop
-  endfacet
-  facet normal -0.999701 0.0244476 0
-    outer loop
-      vertex 14 6 3
-      vertex 13.9976 5.90186 0.00999928
-      vertex 13.9976 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal -0.817707 0.575635 0
-    outer loop
-      vertex 13.6064 4.8086 0.00999928
-      vertex 13.6629 4.88886 3.21412
-      vertex 13.6629 4.88886 0.00999928
-    endloop
-  endfacet
-  facet normal -0.817534 0.575881 -9.2087e-06
-    outer loop
-      vertex 13.6629 4.88886 3.21412
-      vertex 13.6064 4.8086 0.00999928
-      vertex 13.6369 4.85195 3.22836
-    endloop
-  endfacet
-  facet normal -0.817856 0.575423 0
-    outer loop
-      vertex 13.6369 4.85195 3.22836
-      vertex 13.6064 4.8086 0.00999928
-      vertex 13.6064 4.8086 3.24758
-    endloop
-  endfacet
-  facet normal -0.359859 -0.933007 0
-    outer loop
-      vertex 12.6738 7.88309 0.00999928
-      vertex 12.7654 7.84776 3.01
-      vertex 12.6738 7.88309 3.01
-    endloop
-  endfacet
-  facet normal -0.359859 -0.933007 -0
-    outer loop
-      vertex 12.7654 7.84776 3.01
-      vertex 12.6738 7.88309 0.00999928
-      vertex 12.7654 7.84776 0.00999928
-    endloop
-  endfacet
-  facet normal 0.0245594 -0.999698 0
-    outer loop
-      vertex 11.9019 7.99759 0.00999928
-      vertex 12 8 3.01
-      vertex 11.9019 7.99759 3.01
-    endloop
-  endfacet
-  facet normal 0.0245594 -0.999698 0
-    outer loop
-      vertex 12 8 3.01
-      vertex 11.9019 7.99759 0.00999928
-      vertex 12 8 0.00999928
-    endloop
-  endfacet
-  facet normal -0.535173 -0.844742 0
-    outer loop
-      vertex 13.0282 7.71546 0.00999928
-      vertex 13.1111 7.66294 3.01
-      vertex 13.0282 7.71546 3.01
-    endloop
-  endfacet
-  facet normal -0.535173 -0.844742 -0
-    outer loop
-      vertex 13.1111 7.66294 3.01
-      vertex 13.0282 7.71546 0.00999928
-      vertex 13.1111 7.66294 0.00999928
-    endloop
-  endfacet
-  facet normal 0.689525 0.724261 -0
-    outer loop
-      vertex 10.6569 4.5181 0.00999928
-      vertex 10.5858 4.58579 3.35425
-      vertex 10.6569 4.5181 3.39259
-    endloop
-  endfacet
-  facet normal 0.689525 0.724261 0
-    outer loop
-      vertex 10.5858 4.58579 3.35425
-      vertex 10.6569 4.5181 0.00999928
-      vertex 10.5858 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal -0.963729 0.266882 0
-    outer loop
-      vertex 13.9139 5.41943 0.00999928
-      vertex 13.9401 5.51404 3.04041
-      vertex 13.9401 5.51404 0.00999928
-    endloop
-  endfacet
-  facet normal -0.963729 0.266882 0
-    outer loop
-      vertex 13.9401 5.51404 3.04041
-      vertex 13.9139 5.41943 0.00999928
-      vertex 13.9139 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0.359859 0.933007 -0
-    outer loop
-      vertex 11.3262 4.11691 0.00999928
-      vertex 11.2346 4.15224 3.63772
-      vertex 11.3262 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal 0.359859 0.933007 0
-    outer loop
-      vertex 11.2346 4.15224 3.63772
-      vertex 11.3262 4.11691 0.00999928
-      vertex 11.2346 4.15224 0.00999928
-    endloop
-  endfacet
-  facet normal -0.689525 -0.724261 0
-    outer loop
-      vertex 13.3431 7.4819 0.00999928
-      vertex 13.4142 7.41421 3.01
-      vertex 13.3431 7.4819 3.01
-    endloop
-  endfacet
-  facet normal -0.689525 -0.724261 -0
-    outer loop
-      vertex 13.4142 7.41421 3.01
-      vertex 13.3431 7.4819 0.00999928
-      vertex 13.4142 7.41421 0.00999928
-    endloop
-  endfacet
-  facet normal -0.757297 0.653071 0
-    outer loop
-      vertex 13.4819 4.65688 0.00999928
-      vertex 13.546 4.73121 3.28188
-      vertex 13.546 4.73121 0.00999928
-    endloop
-  endfacet
-  facet normal -0.756488 0.654008 -3.71393e-05
-    outer loop
-      vertex 13.546 4.73121 3.28188
-      vertex 13.4819 4.65688 0.00999928
-      vertex 13.534 4.71733 3.28803
-    endloop
-  endfacet
-  facet normal -0.757485 0.652853 0
-    outer loop
-      vertex 13.534 4.71733 3.28803
-      vertex 13.4819 4.65688 0.00999928
-      vertex 13.4819 4.65688 3.31846
-    endloop
-  endfacet
-  facet normal 0.933096 -0.359628 0
-    outer loop
-      vertex 10.1169 6.67378 3.01
-      vertex 10.1522 6.76537 0.00999928
-      vertex 10.1522 6.76537 3.01
-    endloop
-  endfacet
-  facet normal 0.933096 -0.359628 0
-    outer loop
-      vertex 10.1522 6.76537 0.00999928
-      vertex 10.1169 6.67378 3.01
-      vertex 10.1169 6.67378 0.00999928
-    endloop
-  endfacet
-  facet normal -0.985248 0.171135 0
-    outer loop
-      vertex 13.9616 5.60982 0.00999928
-      vertex 13.9784 5.70654 3.0144
-      vertex 13.9784 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal -0.985937 0.167119 0.000133127
-    outer loop
-      vertex 13.9784 5.70654 3.0144
-      vertex 13.9616 5.60982 0.00999928
-      vertex 13.9783 5.70595 3.01445
-    endloop
-  endfacet
-  facet normal -0.985243 0.17116 0
-    outer loop
-      vertex 13.9783 5.70595 3.01445
-      vertex 13.9616 5.60982 0.00999928
-      vertex 13.9616 5.60982 3.0263
-    endloop
-  endfacet
-  facet normal -0.724162 0.68963 0
-    outer loop
-      vertex 13.4142 4.58579 0.00999928
-      vertex 13.4819 4.65688 3.31846
-      vertex 13.4819 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724066 0.68973 -4.12488e-06
-    outer loop
-      vertex 13.4819 4.65688 3.31846
-      vertex 13.4142 4.58579 0.00999928
-      vertex 13.4142 4.58581 3.35424
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 13.4142 4.58581 3.35424
-      vertex 13.4142 4.58579 0.00999928
-      vertex 13.4142 4.58579 3.35425
-    endloop
-  endfacet
-  facet normal -0.689525 0.724261 0
-    outer loop
-      vertex 13.3431 4.5181 0.00999928
-      vertex 13.4142 4.58579 3.35425
-      vertex 13.4142 4.58579 0.00999928
-    endloop
-  endfacet
-  facet normal -0.689525 0.724261 0
-    outer loop
-      vertex 13.4142 4.58579 3.35425
-      vertex 13.3431 4.5181 0.00999928
-      vertex 13.3431 4.5181 3.39259
-    endloop
-  endfacet
-  facet normal 0.122356 0.992486 -0
-    outer loop
-      vertex 11.804 4.00963 0.00999928
-      vertex 11.7065 4.02165 3.74581
-      vertex 11.804 4.00963 3.75618
-    endloop
-  endfacet
-  facet normal 0.122356 0.992486 0
-    outer loop
-      vertex 11.7065 4.02165 3.74581
-      vertex 11.804 4.00963 0.00999928
-      vertex 11.7065 4.02165 0.00999928
-    endloop
-  endfacet
-  facet normal 0.724066 0.68973 -4.12488e-06
-    outer loop
-      vertex 10.5858 4.58579 0.00999928
-      vertex 10.5181 4.65688 3.31846
-      vertex 10.5858 4.58581 3.35424
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 10.5858 4.58579 0.00999928
-      vertex 10.5858 4.58581 3.35424
-      vertex 10.5858 4.58579 3.35425
-    endloop
-  endfacet
-  facet normal 0.724162 0.68963 0
-    outer loop
-      vertex 10.5181 4.65688 3.31846
-      vertex 10.5858 4.58579 0.00999928
-      vertex 10.5181 4.65688 0.00999928
-    endloop
-  endfacet
-  facet normal -0.31369 -0.949526 0
-    outer loop
-      vertex 12.5806 7.91388 0.00999928
-      vertex 12.6738 7.88309 3.01
-      vertex 12.5806 7.91388 3.01
-    endloop
-  endfacet
-  facet normal -0.31369 -0.949526 -0
-    outer loop
-      vertex 12.6738 7.88309 3.01
-      vertex 12.5806 7.91388 0.00999928
-      vertex 12.6738 7.88309 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724162 -0.68963 0
-    outer loop
-      vertex 13.4819 7.34312 0.00999928
-      vertex 13.4142 7.41421 3.01
-      vertex 13.4142 7.41421 0.00999928
-    endloop
-  endfacet
-  facet normal -0.724162 -0.68963 0
-    outer loop
-      vertex 13.4142 7.41421 3.01
-      vertex 13.4819 7.34312 0.00999928
-      vertex 13.4819 7.34312 3.01
-    endloop
-  endfacet
-  facet normal 0.266719 -0.963774 0
-    outer loop
-      vertex 11.4194 7.91388 0.00999928
-      vertex 11.514 7.94006 3.01
-      vertex 11.4194 7.91388 3.01
-    endloop
-  endfacet
-  facet normal 0.266719 -0.963774 0
-    outer loop
-      vertex 11.514 7.94006 3.01
-      vertex 11.4194 7.91388 0.00999928
-      vertex 11.514 7.94006 0.00999928
-    endloop
-  endfacet
-  facet normal -0.949505 -0.313751 0
-    outer loop
-      vertex 13.9139 6.58057 0.00999928
-      vertex 13.8831 6.67378 3.01
-      vertex 13.8831 6.67378 0.00999928
-    endloop
-  endfacet
-  facet normal -0.949505 -0.313751 0
-    outer loop
-      vertex 13.8831 6.67378 3.01
-      vertex 13.9139 6.58057 0.00999928
-      vertex 13.9139 6.58057 3.01
-    endloop
-  endfacet
-  facet normal -0.870455 -0.492249 0
-    outer loop
-      vertex 13.7638 6.94279 0.00999928
-      vertex 13.7155 7.0282 3.01
-      vertex 13.7155 7.0282 0.00999928
-    endloop
-  endfacet
-  facet normal -0.870455 -0.492249 0
-    outer loop
-      vertex 13.7155 7.0282 3.01
-      vertex 13.7638 6.94279 0.00999928
-      vertex 13.7638 6.94279 3.01
-    endloop
-  endfacet
-  facet normal 0.963729 0.266882 -0
-    outer loop
-      vertex 10.0861 5.41943 0.00999928
-      vertex 10.0599 5.51404 3.04041
-      vertex 10.0861 5.41943 3.05683
-    endloop
-  endfacet
-  facet normal 0.963729 0.266882 0
-    outer loop
-      vertex 10.0599 5.51404 3.04041
-      vertex 10.0861 5.41943 0.00999928
-      vertex 10.0599 5.51404 0.00999928
-    endloop
-  endfacet
-  facet normal -0.266719 0.963774 0
-    outer loop
-      vertex 12.486 4.05994 0.00999928
-      vertex 12.5806 4.08612 3.6902
-      vertex 12.5806 4.08612 0.00999928
-    endloop
-  endfacet
-  facet normal -0.266719 0.963774 0
-    outer loop
-      vertex 12.5806 4.08612 3.6902
-      vertex 12.486 4.05994 0.00999928
-      vertex 12.486 4.05994 3.71278
-    endloop
-  endfacet
-  facet normal -0.997319 0.0731828 0
-    outer loop
-      vertex 13.9976 5.90186 0.00999928
-      vertex 13.994 5.8528 3.00361
-      vertex 13.9976 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal -0.997306 0.0733538 2.8179e-06
-    outer loop
-      vertex 13.9904 5.80397 0.00999928
-      vertex 13.994 5.8528 3.00361
-      vertex 13.9976 5.90186 0.00999928
-    endloop
-  endfacet
-  facet normal -0.997293 0.0735256 0
-    outer loop
-      vertex 13.994 5.8528 3.00361
-      vertex 13.9904 5.80397 0.00999928
-      vertex 13.9904 5.80397 3.00722
-    endloop
-  endfacet
-  facet normal -0.892956 -0.450144 0
-    outer loop
-      vertex 13.808 6.85511 0.00999928
-      vertex 13.7638 6.94279 3.01
-      vertex 13.7638 6.94279 0.00999928
-    endloop
-  endfacet
-  facet normal -0.892956 -0.450144 0
-    outer loop
-      vertex 13.7638 6.94279 3.01
-      vertex 13.808 6.85511 0.00999928
-      vertex 13.808 6.85511 3.01
-    endloop
-  endfacet
-  facet normal -0.122356 0.992486 0
-    outer loop
-      vertex 12.196 4.00963 0.00999928
-      vertex 12.2935 4.02165 3.74581
-      vertex 12.2935 4.02165 0.00999928
-    endloop
-  endfacet
-  facet normal -0.122356 0.992486 0
-    outer loop
-      vertex 12.2935 4.02165 3.74581
-      vertex 12.196 4.00963 0.00999928
-      vertex 12.196 4.00963 3.75618
-    endloop
-  endfacet
-  facet normal -0.170971 0.985276 0
-    outer loop
-      vertex 12.2935 4.02165 0.00999928
-      vertex 12.3902 4.03843 3.73134
-      vertex 12.3902 4.03843 0.00999928
-    endloop
-  endfacet
-  facet normal -0.170971 0.985276 0
-    outer loop
-      vertex 12.3902 4.03843 3.73134
-      vertex 12.2935 4.02165 0.00999928
-      vertex 12.2935 4.02165 3.74581
-    endloop
-  endfacet
-  facet normal 0.449451 0.893305 -0
-    outer loop
-      vertex 11.1449 4.19202 0.00999928
-      vertex 11.1034 4.2129 3.59038
-      vertex 11.1449 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal 0.449686 0.893187 3.40941e-06
-    outer loop
-      vertex 11.1449 4.19202 0.00999928
-      vertex 11.0572 4.23616 3.574
-      vertex 11.1034 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal 0.449575 0.893243 0
-    outer loop
-      vertex 11.0572 4.23616 3.574
-      vertex 11.1449 4.19202 0.00999928
-      vertex 11.0572 4.23616 0.00999928
-    endloop
-  endfacet
-  facet normal 0.689525 -0.724261 0
-    outer loop
-      vertex 10.5858 7.41421 0.00999928
-      vertex 10.6569 7.4819 3.01
-      vertex 10.5858 7.41421 3.01
-    endloop
-  endfacet
-  facet normal 0.689525 -0.724261 0
-    outer loop
-      vertex 10.6569 7.4819 3.01
-      vertex 10.5858 7.41421 0.00999928
-      vertex 10.6569 7.4819 0.00999928
-    endloop
-  endfacet
-  facet normal 0.615209 0.788364 -0
-    outer loop
-      vertex 10.8086 4.39358 0.00999928
-      vertex 10.7312 4.45398 3.42917
-      vertex 10.8086 4.39358 3.46741
-    endloop
-  endfacet
-  facet normal 0.615209 0.788364 0
-    outer loop
-      vertex 10.7312 4.45398 3.42917
-      vertex 10.8086 4.39358 0.00999928
-      vertex 10.7312 4.45398 0.00999928
-    endloop
-  endfacet
-  facet normal 0.999701 0.0244476 -0
-    outer loop
-      vertex 10.0024 5.90186 0.00999928
-      vertex 10 6 3
-      vertex 10.0024 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal 0.999701 0.0244476 0
-    outer loop
-      vertex 10 6 3
-      vertex 10.0024 5.90186 0.00999928
-      vertex 10 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0.170971 -0.985276 0
-    outer loop
-      vertex 11.6098 7.96157 0.00999928
-      vertex 11.7065 7.97835 3.01
-      vertex 11.6098 7.96157 3.01
-    endloop
-  endfacet
-  facet normal 0.170971 -0.985276 0
-    outer loop
-      vertex 11.7065 7.97835 3.01
-      vertex 11.6098 7.96157 0.00999928
-      vertex 11.7065 7.97835 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 0.122242 0
-    outer loop
-      vertex 13.9784 5.70654 0.00999928
-      vertex 13.9904 5.80397 3.00722
-      vertex 13.9904 5.80397 0.00999928
-    endloop
-  endfacet
-  facet normal -0.9925 0.122242 0
-    outer loop
-      vertex 13.9904 5.80397 3.00722
-      vertex 13.9784 5.70654 0.00999928
-      vertex 13.9784 5.70654 3.0144
-    endloop
-  endfacet
-  facet normal 0.724162 -0.68963 0
-    outer loop
-      vertex 10.5181 7.34312 3.01
-      vertex 10.5858 7.41421 0.00999928
-      vertex 10.5858 7.41421 3.01
-    endloop
-  endfacet
-  facet normal 0.724162 -0.68963 0
-    outer loop
-      vertex 10.5858 7.41421 0.00999928
-      vertex 10.5181 7.34312 3.01
-      vertex 10.5181 7.34312 0.00999928
-    endloop
-  endfacet
-  facet normal -0.949505 0.313751 0
-    outer loop
-      vertex 13.8831 5.32622 0.00999928
-      vertex 13.9139 5.41943 3.05683
-      vertex 13.9139 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal -0.946665 0.322219 -0.000287769
-    outer loop
-      vertex 13.9139 5.41943 3.05683
-      vertex 13.8831 5.32622 0.00999928
-      vertex 13.9123 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal -0.949655 0.313297 0
-    outer loop
-      vertex 13.9123 5.41473 3.05764
-      vertex 13.8831 5.32622 0.00999928
-      vertex 13.8831 5.32622 3.07752
-    endloop
-  endfacet
-  facet normal 0.122356 -0.992486 0
-    outer loop
-      vertex 11.7065 7.97835 0.00999928
-      vertex 11.804 7.99037 3.01
-      vertex 11.7065 7.97835 3.01
-    endloop
-  endfacet
-  facet normal 0.122356 -0.992486 0
-    outer loop
-      vertex 11.804 7.99037 3.01
-      vertex 11.7065 7.97835 0.00999928
-      vertex 11.804 7.99037 0.00999928
-    endloop
-  endfacet
-  facet normal -0.170971 -0.985276 0
-    outer loop
-      vertex 12.2935 7.97835 0.00999928
-      vertex 12.3902 7.96157 3.01
-      vertex 12.2935 7.97835 3.01
-    endloop
-  endfacet
-  facet normal -0.170971 -0.985276 -0
-    outer loop
-      vertex 12.3902 7.96157 3.01
-      vertex 12.2935 7.97835 0.00999928
-      vertex 12.3902 7.96157 0.00999928
-    endloop
-  endfacet
-  facet normal 0.844491 -0.53557 0
-    outer loop
-      vertex 10.2845 7.0282 3.01
-      vertex 10.3371 7.11114 0.00999928
-      vertex 10.3371 7.11114 3.01
-    endloop
-  endfacet
-  facet normal 0.844491 -0.53557 0
-    outer loop
-      vertex 10.3371 7.11114 0.00999928
-      vertex 10.2845 7.0282 3.01
-      vertex 10.2845 7.0282 0.00999928
-    endloop
-  endfacet
-  facet normal 0.985937 0.167119 0.000133127
-    outer loop
-      vertex 10.0384 5.60982 0.00999928
-      vertex 10.0216 5.70654 3.0144
-      vertex 10.0217 5.70595 3.01445
-    endloop
-  endfacet
-  facet normal 0.985243 0.17116 -0
-    outer loop
-      vertex 10.0384 5.60982 0.00999928
-      vertex 10.0217 5.70595 3.01445
-      vertex 10.0384 5.60982 3.0263
-    endloop
-  endfacet
-  facet normal 0.985248 0.171135 0
-    outer loop
-      vertex 10.0216 5.70654 3.0144
-      vertex 10.0384 5.60982 0.00999928
-      vertex 10.0216 5.70654 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575647 -0.817698 0
-    outer loop
-      vertex 13.1111 7.66294 0.00999928
-      vertex 13.1914 7.60641 3.01
-      vertex 13.1111 7.66294 3.01
-    endloop
-  endfacet
-  facet normal -0.575647 -0.817698 -0
-    outer loop
-      vertex 13.1914 7.60641 3.01
-      vertex 13.1111 7.66294 0.00999928
-      vertex 13.1914 7.60641 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575579 0.817746 0
-    outer loop
-      vertex 13.1111 4.33706 0.00999928
-      vertex 13.1914 4.39358 3.46741
-      vertex 13.1914 4.39358 0.00999928
-    endloop
-  endfacet
-  facet normal -0.575579 0.817746 0
-    outer loop
-      vertex 13.1914 4.39358 3.46741
-      vertex 13.1111 4.33706 0.00999928
-      vertex 13.1111 4.33706 3.5032
-    endloop
-  endfacet
-  facet normal -0.963729 -0.266882 0
-    outer loop
-      vertex 13.9401 6.48596 0.00999928
-      vertex 13.9139 6.58057 3.01
-      vertex 13.9139 6.58057 0.00999928
-    endloop
-  endfacet
-  facet normal -0.963729 -0.266882 0
-    outer loop
-      vertex 13.9139 6.58057 3.01
-      vertex 13.9401 6.48596 0.00999928
-      vertex 13.9401 6.48596 3.01
-    endloop
-  endfacet
-  facet normal -0.914131 -0.40542 0
-    outer loop
-      vertex 13.8478 6.76537 0.00999928
-      vertex 13.808 6.85511 3.01
-      vertex 13.808 6.85511 0.00999928
-    endloop
-  endfacet
-  facet normal -0.914131 -0.40542 0
-    outer loop
-      vertex 13.808 6.85511 3.01
-      vertex 13.8478 6.76537 0.00999928
-      vertex 13.8478 6.76537 3.01
-    endloop
-  endfacet
-  facet normal 0.313589 0.949559 -0
-    outer loop
-      vertex 11.4194 4.08612 0.00999928
-      vertex 11.387 4.09682 3.68097
-      vertex 11.4194 4.08612 3.6902
-    endloop
-  endfacet
-  facet normal 0.313743 0.949508 1.51104e-06
-    outer loop
-      vertex 11.4194 4.08612 0.00999928
-      vertex 11.3262 4.11691 3.66529
-      vertex 11.387 4.09682 3.68097
-    endloop
-  endfacet
-  facet normal 0.31369 0.949526 0
-    outer loop
-      vertex 11.3262 4.11691 3.66529
-      vertex 11.4194 4.08612 0.00999928
-      vertex 11.3262 4.11691 0.00999928
-    endloop
-  endfacet
-  facet normal -0.97572 -0.219023 0
-    outer loop
-      vertex 13.9616 6.39018 0.00999928
-      vertex 13.9401 6.48596 3.01
-      vertex 13.9401 6.48596 0.00999928
-    endloop
-  endfacet
-  facet normal -0.97572 -0.219023 0
-    outer loop
-      vertex 13.9401 6.48596 3.01
-      vertex 13.9616 6.39018 0.00999928
-      vertex 13.9616 6.39018 3.01
-    endloop
-  endfacet
-  facet normal -0.0245594 0.999698 0
-    outer loop
-      vertex 12 4 0.00999928
-      vertex 12.0981 4.00241 3.76241
-      vertex 12.0981 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal -0.0245594 0.999698 0
-    outer loop
-      vertex 12.0981 4.00241 3.76241
-      vertex 12 4 0.00999928
-      vertex 12 4 3.76449
-    endloop
-  endfacet
-  facet normal 0.756488 0.654008 -3.71393e-05
-    outer loop
-      vertex 10.5181 4.65688 0.00999928
-      vertex 10.454 4.73121 3.28188
-      vertex 10.466 4.71733 3.28803
-    endloop
-  endfacet
-  facet normal 0.757485 0.652853 -0
-    outer loop
-      vertex 10.5181 4.65688 0.00999928
-      vertex 10.466 4.71733 3.28803
-      vertex 10.5181 4.65688 3.31846
-    endloop
-  endfacet
-  facet normal 0.757297 0.653071 0
-    outer loop
-      vertex 10.454 4.73121 3.28188
-      vertex 10.5181 4.65688 0.00999928
-      vertex 10.454 4.73121 0.00999928
-    endloop
-  endfacet
-  facet normal -0.933096 -0.359628 0
-    outer loop
-      vertex 13.8831 6.67378 0.00999928
-      vertex 13.8478 6.76537 3.01
-      vertex 13.8478 6.76537 0.00999928
-    endloop
-  endfacet
-  facet normal -0.933096 -0.359628 0
-    outer loop
-      vertex 13.8478 6.76537 3.01
-      vertex 13.8831 6.67378 0.00999928
-      vertex 13.8831 6.67378 3.01
-    endloop
-  endfacet
-  facet normal -0.985248 -0.171135 0
-    outer loop
-      vertex 13.9784 6.29346 0.00999928
-      vertex 13.9616 6.39018 3.01
-      vertex 13.9616 6.39018 0.00999928
-    endloop
-  endfacet
-  facet normal -0.985248 -0.171135 0
-    outer loop
-      vertex 13.9616 6.39018 3.01
-      vertex 13.9784 6.29346 0.00999928
-      vertex 13.9784 6.29346 3.01
-    endloop
-  endfacet
-  facet normal 0.788325 0.615259 -0
-    outer loop
-      vertex 10.454 4.73121 0.00999928
-      vertex 10.3936 4.8086 3.24758
-      vertex 10.454 4.73121 3.28188
-    endloop
-  endfacet
-  facet normal 0.788325 0.615259 0
-    outer loop
-      vertex 10.3936 4.8086 3.24758
-      vertex 10.454 4.73121 0.00999928
-      vertex 10.3936 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal 0.914131 0.40542 -0
-    outer loop
-      vertex 10.192 5.14489 0.00999928
-      vertex 10.1522 5.23463 3.09999
-      vertex 10.192 5.14489 3.12482
-    endloop
-  endfacet
-  facet normal 0.914131 0.40542 0
-    outer loop
-      vertex 10.1522 5.23463 3.09999
-      vertex 10.192 5.14489 0.00999928
-      vertex 10.1522 5.23463 0.00999928
-    endloop
-  endfacet
-  facet normal -0.359859 0.933007 0
-    outer loop
-      vertex 12.6738 4.11691 0.00999928
-      vertex 12.7654 4.15224 3.63772
-      vertex 12.7654 4.15224 0.00999928
-    endloop
-  endfacet
-  facet normal -0.359859 0.933007 0
-    outer loop
-      vertex 12.7654 4.15224 3.63772
-      vertex 12.6738 4.11691 0.00999928
-      vertex 12.6738 4.11691 3.66529
-    endloop
-  endfacet
-  facet normal -0.870479 0.492205 0
-    outer loop
-      vertex 13.7155 4.97179 0.00999928
-      vertex 13.7638 5.05721 3.15294
-      vertex 13.7638 5.05721 0.00999928
-    endloop
-  endfacet
-  facet normal -0.870382 0.492377 -6.16218e-06
-    outer loop
-      vertex 13.7638 5.05721 3.15294
-      vertex 13.7155 4.97179 0.00999928
-      vertex 13.7254 4.98933 3.17537
-    endloop
-  endfacet
-  facet normal -0.870859 0.491534 0
-    outer loop
-      vertex 13.7254 4.98933 3.17537
-      vertex 13.7155 4.97179 0.00999928
-      vertex 13.7155 4.97179 3.18213
-    endloop
-  endfacet
-  facet normal -0.49291 0.87008 0
-    outer loop
-      vertex 12.9428 4.23616 0.00999928
-      vertex 13.0282 4.28454 3.53992
-      vertex 13.0282 4.28454 0.00999928
-    endloop
-  endfacet
-  facet normal -0.49291 0.87008 0
-    outer loop
-      vertex 13.0282 4.28454 3.53992
-      vertex 12.9428 4.23616 0.00999928
-      vertex 12.9428 4.23616 3.574
-    endloop
-  endfacet
-  facet normal -0.817707 -0.575635 0
-    outer loop
-      vertex 13.6629 7.11114 0.00999928
-      vertex 13.6064 7.1914 3.01
-      vertex 13.6064 7.1914 0.00999928
-    endloop
-  endfacet
-  facet normal -0.817707 -0.575635 0
-    outer loop
-      vertex 13.6064 7.1914 3.01
-      vertex 13.6629 7.11114 0.00999928
-      vertex 13.6629 7.11114 3.01
-    endloop
-  endfacet
-  facet normal 0.975411 0.220393 -4.57252e-05
-    outer loop
-      vertex 10.0599 5.51404 0.00999928
-      vertex 10.0384 5.60982 3.0263
-      vertex 10.0497 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal 0.976056 0.217517 -0
-    outer loop
-      vertex 10.0599 5.51404 0.00999928
-      vertex 10.0497 5.55981 3.03247
-      vertex 10.0599 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal 0.97572 0.219023 0
-    outer loop
-      vertex 10.0384 5.60982 3.0263
-      vertex 10.0599 5.51404 0.00999928
-      vertex 10.0384 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal -0.653339 -0.757066 0
-    outer loop
-      vertex 13.2688 7.54602 0.00999928
-      vertex 13.3431 7.4819 3.01
-      vertex 13.2688 7.54602 3.01
-    endloop
-  endfacet
-  facet normal -0.653339 -0.757066 -0
-    outer loop
-      vertex 13.3431 7.4819 3.01
-      vertex 13.2688 7.54602 0.00999928
-      vertex 13.3431 7.4819 0.00999928
-    endloop
-  endfacet
-  facet normal 0.9925 0.122242 -0
-    outer loop
-      vertex 10.0216 5.70654 0.00999928
-      vertex 10.0096 5.80397 3.00722
-      vertex 10.0216 5.70654 3.0144
-    endloop
-  endfacet
-  facet normal 0.9925 0.122242 0
-    outer loop
-      vertex 10.0096 5.80397 3.00722
-      vertex 10.0216 5.70654 0.00999928
-      vertex 10.0096 5.80397 0.00999928
-    endloop
-  endfacet
-  facet normal 0.073549 0.997292 -0
-    outer loop
-      vertex 11.9019 4.00241 0.00999928
-      vertex 11.804 4.00963 3.75618
-      vertex 11.9019 4.00241 3.76241
-    endloop
-  endfacet
-  facet normal 0.073549 0.997292 0
-    outer loop
-      vertex 11.804 4.00963 3.75618
-      vertex 11.9019 4.00241 0.00999928
-      vertex 11.804 4.00963 0.00999928
-    endloop
-  endfacet
-  facet normal 0.997319 0.0731828 0
-    outer loop
-      vertex 10.006 5.8528 3.00361
-      vertex 10.0024 5.90186 0.00999928
-      vertex 10.0024 5.90186 3.00241
-    endloop
-  endfacet
-  facet normal 0.997293 0.0735256 -0
-    outer loop
-      vertex 10.0096 5.80397 0.00999928
-      vertex 10.006 5.8528 3.00361
-      vertex 10.0096 5.80397 3.00722
-    endloop
-  endfacet
-  facet normal 0.997306 0.0733538 2.8179e-06
-    outer loop
-      vertex 10.006 5.8528 3.00361
-      vertex 10.0096 5.80397 0.00999928
-      vertex 10.0024 5.90186 0.00999928
-    endloop
-  endfacet
-  facet normal 0.870382 0.492377 -6.16218e-06
-    outer loop
-      vertex 10.2845 4.97179 0.00999928
-      vertex 10.2362 5.05721 3.15294
-      vertex 10.2746 4.98933 3.17537
-    endloop
-  endfacet
-  facet normal 0.870859 0.491534 -0
-    outer loop
-      vertex 10.2845 4.97179 0.00999928
-      vertex 10.2746 4.98933 3.17537
-      vertex 10.2845 4.97179 3.18213
-    endloop
-  endfacet
-  facet normal 0.870479 0.492205 0
-    outer loop
-      vertex 10.2362 5.05721 3.15294
-      vertex 10.2845 4.97179 0.00999928
-      vertex 10.2362 5.05721 0.00999928
-    endloop
-  endfacet
-  facet normal 0.405401 -0.914139 0
-    outer loop
-      vertex 11.1449 7.80798 0.00999928
-      vertex 11.2346 7.84776 3.01
-      vertex 11.1449 7.80798 3.01
-    endloop
-  endfacet
-  facet normal 0.405401 -0.914139 0
-    outer loop
-      vertex 11.2346 7.84776 3.01
-      vertex 11.1449 7.80798 0.00999928
-      vertex 11.2346 7.84776 0.00999928
-    endloop
-  endfacet
-  facet normal 0.817707 -0.575635 0
-    outer loop
-      vertex 10.3371 7.11114 3.01
-      vertex 10.3936 7.1914 0.00999928
-      vertex 10.3936 7.1914 3.01
-    endloop
-  endfacet
-  facet normal 0.817707 -0.575635 0
-    outer loop
-      vertex 10.3936 7.1914 0.00999928
-      vertex 10.3371 7.11114 3.01
-      vertex 10.3371 7.11114 0.00999928
-    endloop
-  endfacet
-  facet normal 0.219076 -0.975708 0
-    outer loop
-      vertex 11.514 7.94006 0.00999928
-      vertex 11.6098 7.96157 3.01
-      vertex 11.514 7.94006 3.01
-    endloop
-  endfacet
-  facet normal 0.219076 -0.975708 0
-    outer loop
-      vertex 11.6098 7.96157 3.01
-      vertex 11.514 7.94006 0.00999928
-      vertex 11.6098 7.96157 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449575 0.893243 0
-    outer loop
-      vertex 12.8551 4.19202 0.00999928
-      vertex 12.9428 4.23616 3.574
-      vertex 12.9428 4.23616 0.00999928
-    endloop
-  endfacet
-  facet normal -0.449686 0.893187 3.40941e-06
-    outer loop
-      vertex 12.9428 4.23616 3.574
-      vertex 12.8551 4.19202 0.00999928
-      vertex 12.8966 4.2129 3.59038
-    endloop
-  endfacet
-  facet normal -0.449451 0.893305 0
-    outer loop
-      vertex 12.8966 4.2129 3.59038
-      vertex 12.8551 4.19202 0.00999928
-      vertex 12.8551 4.19202 3.60667
-    endloop
-  endfacet
-  facet normal -0.914131 0.40542 0
-    outer loop
-      vertex 13.808 5.14489 0.00999928
-      vertex 13.8478 5.23463 3.09999
-      vertex 13.8478 5.23463 0.00999928
-    endloop
-  endfacet
-  facet normal -0.914131 0.40542 0
-    outer loop
-      vertex 13.8478 5.23463 3.09999
-      vertex 13.808 5.14489 0.00999928
-      vertex 13.808 5.14489 3.12482
-    endloop
-  endfacet
-  facet normal -0.266719 -0.963774 0
-    outer loop
-      vertex 12.486 7.94006 0.00999928
-      vertex 12.5806 7.91388 3.01
-      vertex 12.486 7.94006 3.01
-    endloop
-  endfacet
-  facet normal -0.266719 -0.963774 -0
-    outer loop
-      vertex 12.5806 7.91388 3.01
-      vertex 12.486 7.94006 0.00999928
-      vertex 12.5806 7.91388 0.00999928
-    endloop
-  endfacet
-  facet normal 0.757297 -0.653071 0
-    outer loop
-      vertex 10.454 7.26879 3.01
-      vertex 10.5181 7.34312 0.00999928
-      vertex 10.5181 7.34312 3.01
-    endloop
-  endfacet
-  facet normal 0.757297 -0.653071 0
-    outer loop
-      vertex 10.5181 7.34312 0.00999928
-      vertex 10.454 7.26879 3.01
-      vertex 10.454 7.26879 0.00999928
-    endloop
-  endfacet
-  facet normal 0.97572 -0.219023 0
-    outer loop
-      vertex 10.0384 6.39018 3.01
-      vertex 10.0599 6.48596 0.00999928
-      vertex 10.0599 6.48596 3.01
-    endloop
-  endfacet
-  facet normal 0.97572 -0.219023 0
-    outer loop
-      vertex 10.0599 6.48596 0.00999928
-      vertex 10.0384 6.39018 3.01
-      vertex 10.0384 6.39018 0.00999928
-    endloop
-  endfacet
-  facet normal 0.170971 0.985276 -0
-    outer loop
-      vertex 11.7065 4.02165 0.00999928
-      vertex 11.6098 4.03843 3.73134
-      vertex 11.7065 4.02165 3.74581
-    endloop
-  endfacet
-  facet normal 0.170971 0.985276 0
-    outer loop
-      vertex 11.6098 4.03843 3.73134
-      vertex 11.7065 4.02165 0.00999928
-      vertex 11.6098 4.03843 0.00999928
-    endloop
-  endfacet
-  facet normal -0.97572 0.219023 0
-    outer loop
-      vertex 13.9401 5.51404 0.00999928
-      vertex 13.9616 5.60982 3.0263
-      vertex 13.9616 5.60982 0.00999928
-    endloop
-  endfacet
-  facet normal -0.975411 0.220393 -4.57252e-05
-    outer loop
-      vertex 13.9616 5.60982 3.0263
-      vertex 13.9401 5.51404 0.00999928
-      vertex 13.9503 5.55981 3.03247
-    endloop
-  endfacet
-  facet normal -0.976056 0.217517 0
-    outer loop
-      vertex 13.9503 5.55981 3.03247
-      vertex 13.9401 5.51404 0.00999928
-      vertex 13.9401 5.51404 3.04041
-    endloop
-  endfacet
-  facet normal -0.933096 0.359628 0
-    outer loop
-      vertex 13.8478 5.23463 0.00999928
-      vertex 13.8831 5.32622 3.07752
-      vertex 13.8831 5.32622 0.00999928
-    endloop
-  endfacet
-  facet normal -0.932867 0.360221 -2.03672e-05
-    outer loop
-      vertex 13.8831 5.32622 3.07752
-      vertex 13.8478 5.23463 0.00999928
-      vertex 13.8618 5.27106 3.08991
-    endloop
-  endfacet
-  facet normal -0.933445 0.358722 0
-    outer loop
-      vertex 13.8618 5.27106 3.08991
-      vertex 13.8478 5.23463 0.00999928
-      vertex 13.8478 5.23463 3.09999
-    endloop
-  endfacet
-  facet normal 0.892956 -0.450144 0
-    outer loop
-      vertex 10.192 6.85511 3.01
-      vertex 10.2362 6.94279 0.00999928
-      vertex 10.2362 6.94279 3.01
-    endloop
-  endfacet
-  facet normal 0.892956 -0.450144 0
-    outer loop
-      vertex 10.2362 6.94279 0.00999928
-      vertex 10.192 6.85511 3.01
-      vertex 10.192 6.85511 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 0.615259 0
-    outer loop
-      vertex 13.546 4.73121 0.00999928
-      vertex 13.6064 4.8086 3.24758
-      vertex 13.6064 4.8086 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 0.615259 0
-    outer loop
-      vertex 13.6064 4.8086 3.24758
-      vertex 13.546 4.73121 0.00999928
-      vertex 13.546 4.73121 3.28188
-    endloop
-  endfacet
-  facet normal 0.653253 0.75714 -0
-    outer loop
-      vertex 10.7312 4.45398 0.00999928
-      vertex 10.7269 4.45769 3.42681
-      vertex 10.7312 4.45398 3.42917
-    endloop
-  endfacet
-  facet normal 0.653344 0.757061 1.9929e-07
-    outer loop
-      vertex 10.7312 4.45398 0.00999928
-      vertex 10.6569 4.5181 3.39259
-      vertex 10.7269 4.45769 3.42681
-    endloop
-  endfacet
-  facet normal 0.653339 0.757066 0
-    outer loop
-      vertex 10.6569 4.5181 3.39259
-      vertex 10.7312 4.45398 0.00999928
-      vertex 10.6569 4.5181 0.00999928
-    endloop
-  endfacet
-  facet normal -0.0245594 -0.999698 0
-    outer loop
-      vertex 12 8 0.00999928
-      vertex 12.0981 7.99759 3.01
-      vertex 12 8 3.01
-    endloop
-  endfacet
-  facet normal -0.0245594 -0.999698 -0
-    outer loop
-      vertex 12.0981 7.99759 3.01
-      vertex 12 8 0.00999928
-      vertex 12.0981 7.99759 0.00999928
-    endloop
-  endfacet
-  facet normal 0.788325 -0.615259 0
-    outer loop
-      vertex 10.3936 7.1914 3.01
-      vertex 10.454 7.26879 0.00999928
-      vertex 10.454 7.26879 3.01
-    endloop
-  endfacet
-  facet normal 0.788325 -0.615259 0
-    outer loop
-      vertex 10.454 7.26879 0.00999928
-      vertex 10.3936 7.1914 3.01
-      vertex 10.3936 7.1914 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 -0.615259 0
-    outer loop
-      vertex 13.6064 7.1914 0.00999928
-      vertex 13.546 7.26879 3.01
-      vertex 13.546 7.26879 0.00999928
-    endloop
-  endfacet
-  facet normal -0.788325 -0.615259 0
-    outer loop
-      vertex 13.546 7.26879 3.01
-      vertex 13.6064 7.1914 0.00999928
-      vertex 13.6064 7.1914 3.01
-    endloop
-  endfacet
-  facet normal 0.963729 -0.266882 0
-    outer loop
-      vertex 10.0599 6.48596 3.01
-      vertex 10.0861 6.58057 0.00999928
-      vertex 10.0861 6.58057 3.01
-    endloop
-  endfacet
-  facet normal 0.963729 -0.266882 0
-    outer loop
-      vertex 10.0861 6.58057 0.00999928
-      vertex 10.0599 6.48596 3.01
-      vertex 10.0599 6.48596 0.00999928
-    endloop
-  endfacet
-  facet normal -0.49291 -0.87008 0
-    outer loop
-      vertex 12.9428 7.76384 0.00999928
-      vertex 13.0282 7.71546 3.01
-      vertex 12.9428 7.76384 3.01
-    endloop
-  endfacet
-  facet normal -0.49291 -0.87008 -0
-    outer loop
-      vertex 13.0282 7.71546 3.01
-      vertex 12.9428 7.76384 0.00999928
-      vertex 13.0282 7.71546 0.00999928
-    endloop
-  endfacet
-  facet normal 0.615146 -0.788413 0
-    outer loop
-      vertex 10.7312 7.54602 0.00999928
-      vertex 10.8086 7.60641 3.01
-      vertex 10.7312 7.54602 3.01
-    endloop
-  endfacet
-  facet normal 0.615146 -0.788413 0
-    outer loop
-      vertex 10.8086 7.60641 3.01
-      vertex 10.7312 7.54602 0.00999928
-      vertex 10.8086 7.60641 0.00999928
-    endloop
-  endfacet
-  facet normal 0.653339 -0.757066 0
-    outer loop
-      vertex 10.6569 7.4819 0.00999928
-      vertex 10.7312 7.54602 3.01
-      vertex 10.6569 7.4819 3.01
-    endloop
-  endfacet
-  facet normal 0.653339 -0.757066 0
-    outer loop
-      vertex 10.7312 7.54602 3.01
-      vertex 10.6569 7.4819 0.00999928
-      vertex 10.7312 7.54602 0.00999928
-    endloop
-  endfacet
-  facet normal 0.997293 -0.0735256 0
-    outer loop
-      vertex 10.006 6.1472 3.00361
-      vertex 10.0096 6.19603 0.00999928
-      vertex 10.0096 6.19603 3.00722
-    endloop
-  endfacet
-  facet normal 0.99732 -0.0731681 5.86359e-06
-    outer loop
-      vertex 10.0024 6.09813 3.00241
-      vertex 10.0096 6.19603 0.00999928
-      vertex 10.006 6.1472 3.00361
-    endloop
-  endfacet
-  facet normal 0.997307 -0.0733463 0
-    outer loop
-      vertex 10.0096 6.19603 0.00999928
-      vertex 10.0024 6.09813 3.00241
-      vertex 10.0024 6.09813 0.00999928
-    endloop
-  endfacet
-  facet normal 0.992172 -0.121362 -0.0294284
-    outer loop
-      vertex 10.0096 6.19603 3.00722
-      vertex 10.0216 6.29346 3.01
-      vertex 10.0143 6.23378 3.01
-    endloop
-  endfacet
-  facet normal 0.9925 -0.122242 0
-    outer loop
-      vertex 10.0216 6.29346 3.01
-      vertex 10.0096 6.19603 3.00722
-      vertex 10.0216 6.29346 0.00999928
-    endloop
-  endfacet
-  facet normal 0.9925 -0.122242 0
-    outer loop
-      vertex 10.0216 6.29346 0.00999928
-      vertex 10.0096 6.19603 3.00722
-      vertex 10.0096 6.19603 0.00999928
-    endloop
-  endfacet
-  facet normal 0.999701 -0.02445 0
-    outer loop
-      vertex 10 6 3
-      vertex 10.0024 6.09813 0.00999928
-      vertex 10.0024 6.09813 3.00241
-    endloop
-  endfacet
-  facet normal 0.999701 -0.02445 0
-    outer loop
-      vertex 10.0024 6.09813 0.00999928
-      vertex 10 6 3
-      vertex 10 6 0.00999928
-    endloop
-  endfacet
-  facet normal 0.535173 -0.844742 0
-    outer loop
-      vertex 10.8889 7.66294 0.00999928
-      vertex 10.9718 7.71546 3.01
-      vertex 10.8889 7.66294 3.01
-    endloop
-  endfacet
-  facet normal 0.535173 -0.844742 0
-    outer loop
-      vertex 10.9718 7.71546 3.01
-      vertex 10.8889 7.66294 0.00999928
-      vertex 10.9718 7.71546 0.00999928
-    endloop
-  endfacet
-  facet normal 0.31369 -0.949526 0
-    outer loop
-      vertex 11.3262 7.88309 0.00999928
-      vertex 11.4194 7.91388 3.01
-      vertex 11.3262 7.88309 3.01
-    endloop
-  endfacet
-  facet normal 0.31369 -0.949526 0
-    outer loop
-      vertex 11.4194 7.91388 3.01
-      vertex 11.3262 7.88309 0.00999928
-      vertex 11.4194 7.91388 0.00999928
-    endloop
-  endfacet
-  facet normal 0.914131 -0.40542 0
-    outer loop
-      vertex 10.1522 6.76537 3.01
-      vertex 10.192 6.85511 0.00999928
-      vertex 10.192 6.85511 3.01
-    endloop
-  endfacet
-  facet normal 0.914131 -0.40542 0
-    outer loop
-      vertex 10.192 6.85511 0.00999928
-      vertex 10.1522 6.76537 3.01
-      vertex 10.1522 6.76537 0.00999928
-    endloop
-  endfacet
-  facet normal 0.0245594 0.999698 -0
-    outer loop
-      vertex 12 4 0.00999928
-      vertex 11.9019 4.00241 3.76241
-      vertex 12 4 3.76449
-    endloop
-  endfacet
-  facet normal 0.0245594 0.999698 0
-    outer loop
-      vertex 11.9019 4.00241 3.76241
-      vertex 12 4 0.00999928
-      vertex 11.9019 4.00241 0.00999928
-    endloop
-  endfacet
-  facet normal -0.892956 0.450144 0
-    outer loop
-      vertex 13.7638 5.05721 0.00999928
-      vertex 13.808 5.14489 3.12482
-      vertex 13.808 5.14489 0.00999928
-    endloop
-  endfacet
-  facet normal -0.893739 0.448588 5.49163e-05
-    outer loop
-      vertex 13.808 5.14489 3.12482
-      vertex 13.7638 5.05721 0.00999928
-      vertex 13.8001 5.12915 3.12918
-    endloop
-  endfacet
-  facet normal -0.892783 0.450487 0
-    outer loop
-      vertex 13.8001 5.12915 3.12918
-      vertex 13.7638 5.05721 0.00999928
-      vertex 13.7638 5.05721 3.15294
-    endloop
-  endfacet
-  facet normal 0.870455 -0.492249 0
-    outer loop
-      vertex 10.2362 6.94279 3.01
-      vertex 10.2845 7.0282 0.00999928
-      vertex 10.2845 7.0282 3.01
-    endloop
-  endfacet
-  facet normal 0.870455 -0.492249 0
-    outer loop
-      vertex 10.2845 7.0282 0.00999928
-      vertex 10.2362 6.94279 3.01
-      vertex 10.2362 6.94279 0.00999928
-    endloop
-  endfacet
-  facet normal 0.405401 0.914139 -0
-    outer loop
-      vertex 11.2346 4.15224 0.00999928
-      vertex 11.1449 4.19202 3.60667
-      vertex 11.2346 4.15224 3.63772
-    endloop
-  endfacet
-  facet normal 0.405401 0.914139 0
-    outer loop
-      vertex 11.1449 4.19202 3.60667
-      vertex 11.2346 4.15224 0.00999928
-      vertex 11.1449 4.19202 0.00999928
-    endloop
-  endfacet
-  facet normal 0.946665 0.322219 -0.000287769
-    outer loop
-      vertex 10.1169 5.32622 0.00999928
-      vertex 10.0861 5.41943 3.05683
-      vertex 10.0877 5.41473 3.05764
-    endloop
-  endfacet
-  facet normal 0.949655 0.313297 -0
-    outer loop
-      vertex 10.1169 5.32622 0.00999928
-      vertex 10.0877 5.41473 3.05764
-      vertex 10.1169 5.32622 3.07752
-    endloop
-  endfacet
-  facet normal 0.949505 0.313751 0
-    outer loop
-      vertex 10.0861 5.41943 3.05683
-      vertex 10.1169 5.32622 0.00999928
-      vertex 10.0861 5.41943 0.00999928
-    endloop
-  endfacet
-  facet normal -0.219076 -0.975708 0
-    outer loop
-      vertex 12.3902 7.96157 0.00999928
-      vertex 12.486 7.94006 3.01
-      vertex 12.3902 7.96157 3.01
-    endloop
-  endfacet
-  facet normal -0.219076 -0.975708 -0
-    outer loop
-      vertex 12.486 7.94006 3.01
-      vertex 12.3902 7.96157 0.00999928
-      vertex 12.486 7.94006 0.00999928
-    endloop
-  endfacet
-  facet normal 0.449575 -0.893243 0
-    outer loop
-      vertex 11.0572 7.76384 0.00999928
-      vertex 11.1449 7.80798 3.01
-      vertex 11.0572 7.76384 3.01
-    endloop
-  endfacet
-  facet normal 0.449575 -0.893243 0
-    outer loop
-      vertex 11.1449 7.80798 3.01
-      vertex 11.0572 7.76384 0.00999928
-      vertex 11.1449 7.80798 0.00999928
-    endloop
-  endfacet
-  facet normal 0.534922 0.844902 -0
-    outer loop
-      vertex 10.9718 4.28454 0.00999928
-      vertex 10.8948 4.33329 3.50559
-      vertex 10.9718 4.28454 3.53992
-    endloop
-  endfacet
-  facet normal 0.538415 0.84268 0.000107927
-    outer loop
-      vertex 10.9718 4.28454 0.00999928
-      vertex 10.8889 4.33706 3.5032
-      vertex 10.8948 4.33329 3.50559
-    endloop
-  endfacet
-  facet normal 0.535173 0.844742 0
-    outer loop
-      vertex 10.8889 4.33706 3.5032
-      vertex 10.9718 4.28454 0.00999928
-      vertex 10.8889 4.33706 0.00999928
+  facet normal -1 0 0
+    outer loop
+      vertex 6.25 0 0.01
+      vertex 6.25 3 0.00999928
+      vertex 6.25 0 0.00999928
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 6.25 -4 0.00999928
-      vertex 6.25 3 11.6
       vertex 6.25 3 0.00999928
+      vertex 6.25 0 0.01
+      vertex 6.25 3 11.6
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal -1 0 0
     outer loop
-      vertex 6.25 3 11.6
-      vertex 6.25 -4 0.00999928
       vertex 6.25 -4 11.6
+      vertex 6.25 0 0.01
+      vertex 6.25 -4 0.01
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 6.25 0 0.01
+      vertex 6.25 -4 11.6
+      vertex 6.25 3 11.6
     endloop
   endfacet
   facet normal 0 0 -1
@@ -13957,18 +13999,32 @@ solid OpenSCAD_Model
       vertex -6.25 3 11.6
     endloop
   endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -6.25 3 11.6
+      vertex -6.25 0 0.01
+      vertex -6.25 3 0.00999928
+    endloop
+  endfacet
   facet normal 1 -0 0
     outer loop
       vertex -6.25 -4 11.6
-      vertex -6.25 3 0.00999928
+      vertex -6.25 0 0.01
       vertex -6.25 3 11.6
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -6.25 3 0.00999928
+      vertex -6.25 0 0.01
       vertex -6.25 -4 11.6
-      vertex -6.25 -4 0.00999928
+      vertex -6.25 -4 0.01
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -6.25 3 0.00999928
+      vertex -6.25 0 0.01
+      vertex -6.25 0 0.00999928
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
Hi jhawthorn,

Very nice project indeed. I was having a look at modelh.club and I realised that the 3D printed shim didn't fit perfectly in the case in [this picture](https://modelh.club/modelh_usb_back.jpg), so I modified the openscad design to give it the necessary trapezoid shape.

I kept the original measure for the small side of the trapezoid, but eyeballed the big side. You might have to measure it and change the file.

I know this adds a little more complexity to the design file but I think it would look so much better this way.

Good luck with your project,
Ricardo